### PR TITLE
Adds socket option that fixes the problem with long wait of closing TCP port after closing socket

### DIFF
--- a/src/Socket/Server.php
+++ b/src/Socket/Server.php
@@ -33,6 +33,8 @@ final class Server implements Processable
         private readonly ?Closure $clientInflector,
     ) {
         $this->socket = @\socket_create_listen($port);
+        \socket_set_option($this->socket, \SOL_SOCKET, \SO_LINGER, ['l_linger' => 0, 'l_onoff' => 1]);
+
         if ($this->socket === false) {
             throw new \RuntimeException('Socket create failed.');
         }

--- a/src/Socket/Server.php
+++ b/src/Socket/Server.php
@@ -33,6 +33,7 @@ final class Server implements Processable
         private readonly ?Closure $clientInflector,
     ) {
         $this->socket = @\socket_create_listen($port);
+        /** @link https://github.com/buggregator/trap/pull/14 */
         \socket_set_option($this->socket, \SOL_SOCKET, \SO_LINGER, ['l_linger' => 0, 'l_onoff' => 1]);
 
         if ($this->socket === false) {


### PR DESCRIPTION
In PHP socket programming, the `SO_LINGER` option is used to control the behavior of a socket when it is closed. The linger option specifies whether the socket should remain active for a period of time after it is closed, allowing any pending data to be sent or received.


- `l_linger` specifies the amount of time, in seconds, to linger after the socket is closed. In this case, it is set to `0`, meaning the socket will not linger and will be closed immediately.
- `l_onoff` is a boolean value that determines whether the `l_linger` option is enabled (`1`) or disabled (`0`). In this case, it is set to `1`, indicating that the `l_linger` option is turned on.