### PR TITLE
Fix Client helpers bugs and add tests

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -5,6 +5,8 @@
          colors="true"
          processIsolation="false"
          executionOrder="random"
+         failOnRisky="true"
+         failOnWarning="true"
          stopOnFailure="false"
          stopOnError="false"
          stderr="true"
@@ -22,6 +24,7 @@
         </include>
         <exclude>
             <directory>tests</directory>
+            <directory>src/Test</directory>
         </exclude>
     </source>
 </phpunit>

--- a/psalm.xml
+++ b/psalm.xml
@@ -17,6 +17,7 @@
         <ignoreFiles>
             <directory name="vendor"/>
             <directory name="src/Test"/>
+            <directory name="tests"/>
         </ignoreFiles>
     </projectFiles>
 </psalm>

--- a/src/Client/TrapHandle/ContextProvider/Source.php
+++ b/src/Client/TrapHandle/ContextProvider/Source.php
@@ -3,6 +3,7 @@
 namespace Buggregator\Trap\Client\TrapHandle\ContextProvider;
 
 use Buggregator\Trap\Client\TrapHandle\StackTrace;
+use Buggregator\Trap\Client\TrapHandle\StaticState;
 use Symfony\Component\HttpKernel\Debug\FileLinkFormatter;
 use Symfony\Component\VarDumper\Cloner\VarCloner;
 use Symfony\Component\VarDumper\Dumper\ContextProvider\ContextProviderInterface;
@@ -43,7 +44,8 @@ final class Source implements ContextProviderInterface
 
     public function getContext(): ?array
     {
-        $trace = StackTrace::stackTrace((string)$this->projectDir);
+        \assert(StaticState::getValue() !== null);
+        $trace = StaticState::getValue()->stackTraceWithObjects;
 
         $file = $trace[0]['file'];
         $line = $trace[0]['line'];

--- a/src/Client/TrapHandle/Dumper.php
+++ b/src/Client/TrapHandle/Dumper.php
@@ -9,6 +9,7 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpKernel\Debug\FileLinkFormatter;
 use Symfony\Component\VarDumper\Caster\ReflectionCaster;
+use Symfony\Component\VarDumper\Cloner\DumperInterface;
 use Symfony\Component\VarDumper\Cloner\VarCloner;
 use Symfony\Component\VarDumper\Dumper\CliDumper;
 use Symfony\Component\VarDumper\Dumper\ContextProvider\CliContextProvider;
@@ -16,6 +17,7 @@ use Symfony\Component\VarDumper\Dumper\ContextProvider\ContextProviderInterface;
 use Symfony\Component\VarDumper\Dumper\ContextProvider\RequestContextProvider;
 use Symfony\Component\VarDumper\Dumper\ContextProvider\SourceContextProvider;
 use Symfony\Component\VarDumper\Dumper\ContextualizedDumper;
+use Symfony\Component\VarDumper\Dumper\DataDumperInterface;
 use Symfony\Component\VarDumper\Dumper\HtmlDumper;
 use Symfony\Component\VarDumper\Dumper\ServerDumper;
 
@@ -26,7 +28,7 @@ use Symfony\Component\VarDumper\Dumper\ServerDumper;
 final class Dumper
 {
     /** @var null|Closure(mixed, string|null, int): mixed */
-    private static ?Closure $handler;
+    private static ?Closure $handler = null;
 
     public static function dump(mixed $var, string|int|null $label = null, int $depth = 0): mixed
     {
@@ -40,6 +42,27 @@ final class Dumper
     public static function setHandler(callable $callable = null): ?Closure
     {
         return ([$callable, self::$handler] = [self::$handler, $callable === null ? null : $callable(...)])[0];
+    }
+
+    public static function setDumper(?DataDumperInterface $dumper = null): Closure
+    {
+        if ($dumper === null) {
+            return self::registerHandler();
+        }
+
+        $cloner = new VarCloner();
+        /** @psalm-suppress InvalidArgument */
+        $cloner->addCasters(ReflectionCaster::UNSET_CLOSURE_FILE_INFO);
+
+        return self::$handler = static function (mixed $var, string|null $label = null, int $depth = 0)
+            use ($cloner, $dumper): ?string {
+                $var = $cloner->cloneVar($var);
+
+                $label === null or $var = $var->withContext(['label' => $label]);
+                $depth > 0 and $var = $var->withMaxDepth($depth);
+
+                return $dumper->dump($var);
+            };
     }
 
     /**
@@ -75,15 +98,7 @@ final class Dumper
             $dumper = new ContextualizedDumper($dumper, [new SourceContextProvider()]);
         }
 
-        return self::$handler = static function (mixed $var, string|null $label = null, int $depth = 0)
-        use ($cloner, $dumper): ?string {
-            $var = $cloner->cloneVar($var);
-
-            $label === null or $var = $var->withContext(['label' => $label]);
-            $depth > 0 and $var = $var->withMaxDepth($depth);
-
-            return $dumper->dump($var);
-        };
+        return self::setDumper($dumper);
     }
 
     /**

--- a/src/Client/TrapHandle/StackTrace.php
+++ b/src/Client/TrapHandle/StackTrace.php
@@ -7,6 +7,9 @@ namespace Buggregator\Trap\Client\TrapHandle;
 final class StackTrace
 {
     /**
+     * Returns a backtrace as an array.
+     * Removes the internal frames and the first next frames after them.
+     *
      * @param string $baseDir Base directory for relative paths
      * @return list<array{
      *     function?: string,
@@ -18,13 +21,17 @@ final class StackTrace
      *     args?: list<mixed>
      * }>
      */
-    public static function stackTrace(string $baseDir = ''): array
+    public static function stackTrace(string $baseDir = '', bool $provideObjects = false): array
     {
         $dir = $baseDir . \DIRECTORY_SEPARATOR;
         $cwdLen = \strlen($dir);
         $stack = [];
         $internal = false;
-        foreach (\debug_backtrace(\DEBUG_BACKTRACE_PROVIDE_OBJECT | \DEBUG_BACKTRACE_IGNORE_ARGS) as $frame) {
+        foreach (
+            \debug_backtrace(
+                ($provideObjects ? \DEBUG_BACKTRACE_PROVIDE_OBJECT : 0) | \DEBUG_BACKTRACE_IGNORE_ARGS
+            ) as $frame
+        ) {
             if (\str_starts_with($frame['class'] ?? '', 'Buggregator\\Trap\\Client\\')) {
                 $internal = true;
                 $stack = [];

--- a/src/Client/TrapHandle/StaticState.php
+++ b/src/Client/TrapHandle/StaticState.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Buggregator\Trap\Client\TrapHandle;
+
+/**
+ * @internal
+ * @psalm-internal Buggregator\Trap\Client
+ */
+final class StaticState
+{
+    private function __construct(
+        /**
+         * Simple stack trace without arguments and objects.
+         *
+         * @var list<array{
+         *      function?: string,
+         *      line?: int,
+         *      file?: string,
+         *      class?: class-string,
+         *      type?: string,
+         *      args?: list<mixed>
+         *  }>
+         */
+        public array $stackTrace = [],
+
+        /**
+         * Stack trace without arguments but with objects.
+         *
+         * @var list<array{
+         *      function?: string,
+         *      line?: int,
+         *      file?: string,
+         *      class?: class-string,
+         *      type?: string,
+         *      object?: object,
+         *      args?: list<mixed>
+         *  }>
+         */
+        public array $stackTraceWithObjects = [],
+    ) {
+    }
+
+    private static ?StaticState $value = null;
+
+    public static function new(
+        array $stackTrace = null,
+        array $stackTraceWithObjects = null,
+    ): self
+    {
+        $new = new self(
+            $stackTrace ?? StackTrace::stackTrace(provideObjects: false),
+            $stackTraceWithObjects ?? StackTrace::stackTrace(provideObjects: true),
+        );
+        self::setState($new);
+        return $new;
+    }
+
+    public static function setState(?self $state): void
+    {
+        self::$value = $state;
+    }
+
+    public static function getValue(): ?StaticState
+    {
+        return self::$value;
+    }
+}

--- a/tests/Unit/Client/Base.php
+++ b/tests/Unit/Client/Base.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Buggregator\Trap\Tests\Unit\Client;
+
+use Buggregator\Trap\Client\TrapHandle\Dumper;
+use Closure;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\VarDumper\Caster\ReflectionCaster;
+use Symfony\Component\VarDumper\Cloner\Data;
+use Symfony\Component\VarDumper\Cloner\VarCloner;
+use Symfony\Component\VarDumper\Dumper\DataDumperInterface;
+
+class Base extends TestCase
+{
+    protected static Data $lastData;
+    protected static ?Closure $handler = null;
+
+    protected function setUp(): void
+    {
+        $cloner = new VarCloner();
+        /** @psalm-suppress InvalidArgument */
+        $cloner->addCasters(ReflectionCaster::UNSET_CLOSURE_FILE_INFO);
+        $dumper = $this->getMockBuilder(DataDumperInterface::class)
+            ->getMock();
+        $dumper->expects($this->once())
+            ->method('dump')
+            ->with(
+                $this->callback(static function (Data $data): bool {
+                    static::$lastData = $data;
+                    return true;
+                })
+            )
+            ->willReturnArgument(1);
+
+        Dumper::setDumper($dumper);
+
+        parent::setUp();
+    }
+
+    protected function tearDown(): void
+    {
+        Dumper::setDumper(null);
+        parent::tearDown();
+    }
+}

--- a/tests/Unit/Client/TrapHandle/ContextProvider/SourceTest.php
+++ b/tests/Unit/Client/TrapHandle/ContextProvider/SourceTest.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Buggregator\Trap\Tests\Unit\Client\TrapHandle\ContextProvider;
+
+use Buggregator\Trap\Client\TrapHandle\ContextProvider\Source;
+use Buggregator\Trap\Client\TrapHandle\StaticState;
+use PHPUnit\Framework\TestCase;
+
+use function PHPUnit\Framework\assertSame;
+
+final class SourceTest extends TestCase
+{
+    public function testHere(): void
+    {
+        $this->staticState();
+
+        self::assertSame(\basename(__FILE__), $this->getContext()['name']);
+        self::assertSame(__FILE__, $this->getContext()['file']);
+        self::assertSame(__LINE__ - 4, $this->getContext()['line']);
+    }
+
+    public function testOnDestruct(): void
+    {
+        $this->staticState();
+
+        new class {
+            public function __destruct()
+            {
+                assertSame(\basename(__FILE__), (new Source())->getContext()['name']);
+                assertSame(__FILE__, (new Source())->getContext()['file']);
+            }
+        };
+    }
+
+    /**
+     * @return array{
+     *     name: string,
+     *     file: string,
+     *     line: int,
+     *     file_excerpt: bool
+     * }
+     */
+    private function getContext(): array
+    {
+        return (new Source())->getContext();
+    }
+
+    /**
+     * Create a new StaticState instance.
+     */
+    private function staticState(): StaticState
+    {
+        return StaticState::new();
+    }
+}

--- a/tests/Unit/Client/TrapTest.php
+++ b/tests/Unit/Client/TrapTest.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Buggregator\Trap\Tests\Unit\Client;
+
+final class TrapTest extends Base
+{
+    public function testLabel(): void
+    {
+        trap(FooName: 'foo-value');
+        $this->assertSame('FooName', static::$lastData->getContext()['label']);
+    }
+
+    public function testStackTrace(): void
+    {
+        $line = __FILE__ . ':' . __LINE__ and trap();
+
+        $this->assertArrayHasKey('trace', static::$lastData->getValue());
+
+        $neededLine = \array_key_first(static::$lastData->getValue()['trace']->getValue());
+
+        $this->assertStringContainsString($line, $neededLine);
+    }
+}


### PR DESCRIPTION
Added Client tests;
Fixed:
- Source context provider provides true source path and line
- fixed errors on using for `trap()->once()`