### PR TITLE
Considers id list in `Delete events` action

### DIFF
--- a/src/Sender/Frontend/RPC.php
+++ b/src/Sender/Frontend/RPC.php
@@ -32,26 +32,28 @@ final class RPC
                 return null;
             }
 
-            return $this->callMethod($method);
+            $data = isset($message['data']) && \is_array($message['data']) ? $message['data'] : [];
+
+            return $this->callMethod($method, $data);
         } catch (\Throwable $e) {
             $this->logger->exception($e);
             return null;
         }
     }
 
-    private function callMethod(string $initMethod): ?Message\Rpc
+    private function callMethod(string $initMethod, array $data): ?Message\Rpc
     {
         [$method, $path] = \explode(':', $initMethod, 2) + [1 => ''];
 
         $route = $this->router->match(Method::fromString($method), $path);
 
         if ($route === null) {
-            // todo: Error message?
+            $this->logger->error('RPC method `%s` not found.', $initMethod);
             return null;
         }
 
         /** @var mixed $result */
-        $result = $route();
+        $result = $route(...$data);
         return $result === null ? null : new Message\Rpc(data: $result);
     }
 }

--- a/src/Sender/Frontend/Service.php
+++ b/src/Sender/Frontend/Service.php
@@ -36,7 +36,7 @@ final class Service
     #[
         AssertSuccess(Method::Delete, 'api/event/0145a0e0-0b1a-4e4a-9b1a', ['uuid' => '0145a0e0-0b1a-4e4a-9b1a']),
         AssertFail(Method::Delete, 'api/event/foo-bar-baz'),
-        AssertFail(Method::Delete, 'api/event/')
+        AssertFail(Method::Delete, 'api/event/'),
     ]
     public function eventDelete(string $uuid): Success
     {
@@ -49,7 +49,7 @@ final class Service
     #[
         AssertSuccess(Method::Get, 'api/event/0145a0e0-0b1a-4e4a-9b1a', ['uuid' => '0145a0e0-0b1a-4e4a-9b1a']),
         AssertFail(Method::Get, 'api/event/foo-bar-baz'),
-        AssertFail(Method::Get, 'api/event/')
+        AssertFail(Method::Get, 'api/event/'),
     ]
     public function eventShow(string $uuid): Event|Success
     {
@@ -61,7 +61,8 @@ final class Service
     #[StaticRoute(Method::Delete, 'api/events')]
     #[
         AssertFail(Method::Delete, '/api/events'),
-        AssertFail(Method::Delete, 'api/events/')
+        AssertFail(Method::Delete, 'api/events/'),
+        AssertFail(Method::Delete, 'api/event'),
     ]
     public function eventsDelete(array $uuids = []): Success
     {
@@ -86,8 +87,9 @@ final class Service
 
     #[StaticRoute(Method::Get, 'api/events')]
     #[
+        AssertFail(Method::Get, 'api/event'),
         AssertFail(Method::Post, 'api/events'),
-        AssertFail(Method::Get, '/api/events')
+        AssertFail(Method::Get, '/api/events'),
     ]
     public function eventsList(): EventCollection
     {


### PR DESCRIPTION
Now additional arguments are passed via Websocket RPC.
`Delete all events` action consider passed event ID list to delete

Part of #36