### PR TITLE
Add `trap()->stackTrace()`; maintenance

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 # BSD-3 License
 
-Copyright (c) 2023, Buggregator. All rights reserved.
+Copyright (c) 2023–2024, Buggregator. All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
 following conditions are met:

--- a/src/Client/TrapHandle.php
+++ b/src/Client/TrapHandle.php
@@ -61,7 +61,7 @@ final class TrapHandle
      * The counter isn't incremented if the dump is not sent (any other condition is not met).
      * It might be useful for debugging in loops, recursive or just multiple function calls.
      *
-     * @param positive-int $times
+     * @param positive-int $times Zero means no limit.
      * @param bool $fullStack If true, the counter is incremented for each stack trace, not for the line.
      */
     public function times(int $times, bool $fullStack = false): self
@@ -145,6 +145,7 @@ final class TrapHandle
         }
 
         if ($this->times > 0) {
+            \assert($this->timesCounterKey !== '');
             return Counter::checkAndIncrement($this->timesCounterKey, $this->times);
         }
 

--- a/src/Client/TrapHandle.php
+++ b/src/Client/TrapHandle.php
@@ -46,6 +46,20 @@ final class TrapHandle
     }
 
     /**
+     * Add stack trace to the dump.
+     */
+    public function stackTrace(): self
+    {
+        $cwd = \getcwd();
+        $this->values['Stack trace'] = [
+            'cwd' => $cwd,
+            'trace' => new TraceStub($this->staticState->stackTrace),
+        ];
+
+        return $this;
+    }
+
+    /**
      * Set max depth for the dump.
      *
      * @param int<0, max> $depth If 0 - no limit.
@@ -102,16 +116,6 @@ final class TrapHandle
                 $_SERVER['VAR_DUMPER_SERVER'] = '127.0.0.1:9912';
             }
 
-            // If there are no values - stack trace
-            if ($this->values === []) {
-                VarDumper::dump([
-                    'cwd' => \getcwd(),
-                    // todo StackTrace::stackTrace(\getcwd()) - add CWD
-                    'trace' => new TraceStub($this->staticState->stackTrace),
-                ], depth: $this->depth);
-                return;
-            }
-
             // Dump single value
             if (\array_keys($this->values) === [0]) {
                 VarDumper::dump($this->values[0], depth: $this->depth);
@@ -140,7 +144,7 @@ final class TrapHandle
 
     private function haveToSend(): bool
     {
-        if (!$this->haveToSend) {
+        if (!$this->haveToSend || $this->values === []) {
             return false;
         }
 

--- a/src/Client/TrapHandle/Counter.php
+++ b/src/Client/TrapHandle/Counter.php
@@ -4,14 +4,21 @@ declare(strict_types=1);
 
 namespace Buggregator\Trap\Client\TrapHandle;
 
+/**
+ * Static counter for {@see TrapHandle::once()} and {@see TrapHandle::times()} methods.
+ *
+ * @internal
+ * @psalm-internal Buggregator\Trap\Client
+ */
 final class Counter
 {
-    /** @var array<string, int<0, max>> */
+    /** @var array<non-empty-string, int<0, max>> */
     private static array $counters = [];
 
     /**
      * Returns true if the counter of related stack trace is less than $times. In this case, the counter is incremented.
      *
+     * @param non-empty-string $key
      * @param int<0, max> $times
      */
     public static function checkAndIncrement(string $key, int $times): bool
@@ -24,5 +31,10 @@ final class Counter
         }
 
         return false;
+    }
+
+    public static function clear(): void
+    {
+        self::$counters = [];
     }
 }

--- a/tests/Unit/Client/Base.php
+++ b/tests/Unit/Client/Base.php
@@ -4,27 +4,24 @@ declare(strict_types=1);
 
 namespace Buggregator\Trap\Tests\Unit\Client;
 
+use Buggregator\Trap\Client\TrapHandle\Counter;
 use Buggregator\Trap\Client\TrapHandle\Dumper;
 use Closure;
 use PHPUnit\Framework\TestCase;
-use Symfony\Component\VarDumper\Caster\ReflectionCaster;
 use Symfony\Component\VarDumper\Cloner\Data;
-use Symfony\Component\VarDumper\Cloner\VarCloner;
 use Symfony\Component\VarDumper\Dumper\DataDumperInterface;
 
 class Base extends TestCase
 {
-    protected static Data $lastData;
+    protected static ?Data $lastData = null;
     protected static ?Closure $handler = null;
 
     protected function setUp(): void
     {
-        $cloner = new VarCloner();
-        /** @psalm-suppress InvalidArgument */
-        $cloner->addCasters(ReflectionCaster::UNSET_CLOSURE_FILE_INFO);
+        Counter::clear();
         $dumper = $this->getMockBuilder(DataDumperInterface::class)
             ->getMock();
-        $dumper->expects($this->once())
+        $dumper->expects($this->atLeastOnce())
             ->method('dump')
             ->with(
                 $this->callback(static function (Data $data): bool {
@@ -41,6 +38,7 @@ class Base extends TestCase
 
     protected function tearDown(): void
     {
+        Counter::clear();
         Dumper::setDumper(null);
         parent::tearDown();
     }

--- a/tests/Unit/Client/Base.php
+++ b/tests/Unit/Client/Base.php
@@ -14,14 +14,14 @@ use Symfony\Component\VarDumper\Dumper\DataDumperInterface;
 class Base extends TestCase
 {
     protected static ?Data $lastData = null;
-    protected static ?Closure $handler = null;
 
     protected function setUp(): void
     {
+        self::$lastData = null;
         Counter::clear();
         $dumper = $this->getMockBuilder(DataDumperInterface::class)
             ->getMock();
-        $dumper->expects($this->atLeastOnce())
+        $dumper->expects($this->any())
             ->method('dump')
             ->with(
                 $this->callback(static function (Data $data): bool {
@@ -38,6 +38,7 @@ class Base extends TestCase
 
     protected function tearDown(): void
     {
+        self::$lastData = null;
         Counter::clear();
         Dumper::setDumper(null);
         parent::tearDown();

--- a/tests/Unit/Client/FunctionTrapTest.php
+++ b/tests/Unit/Client/FunctionTrapTest.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Buggregator\Trap\Tests\Unit\Client;
+
+use PHPUnit\Framework\TestCase;
+
+final class FunctionTrapTest extends TestCase
+{
+    /**
+     * @runInSeparateProcess
+     */
+    public function testLeak(): void
+    {
+        $object = new \stdClass();
+        $ref = \WeakReference::create($object);
+
+        \trap($object, $object);
+        unset($object);
+
+        $this->assertNull($ref->get());
+    }
+}

--- a/tests/Unit/Client/TrapTest.php
+++ b/tests/Unit/Client/TrapTest.php
@@ -12,6 +12,9 @@ final class TrapTest extends Base
         $this->assertSame('FooName', static::$lastData->getContext()['label']);
     }
 
+    /**
+     * Check the first line of dumped stacktrace string contains right file and line.
+     */
     public function testStackTrace(): void
     {
         $line = __FILE__ . ':' . __LINE__ and trap();
@@ -21,5 +24,48 @@ final class TrapTest extends Base
         $neededLine = \array_key_first(static::$lastData->getValue()['trace']->getValue());
 
         $this->assertStringContainsString($line, $neededLine);
+    }
+
+    /**
+     * After calling {@see trap()} the dumped data isn't stored in the memory.
+     */
+    public function testLeak(): void
+    {
+        $object = new \stdClass();
+        $ref = \WeakReference::create($object);
+
+        \trap($object, $object);
+        unset($object);
+
+        $this->assertNull($ref->get());
+    }
+
+    public function testTrapOnce(): void
+    {
+        foreach ([false, true, true, true, true] as $isNull) {
+            \trap(42)->once();
+            self::assertSame($isNull, static::$lastData === null);
+            static::$lastData = null;
+        }
+    }
+
+    public static function provideTrapTimes(): iterable
+    {
+        yield 'no limit' => [0, [false, false, false, false, false]];
+        yield 'once' => [1, [false, true, true, true, true, true]];
+        yield 'twice' => [2, [false, false, true, true, true]];
+        yield 'x' => [10, [false, false, false, false, false, false, false, false, false, false, true, true, true]];
+    }
+
+    /**
+     * @dataProvider provideTrapTimes
+     */
+    public function testTrapTimes(int $times, array $sequence): void
+    {
+        foreach ($sequence as $isNull) {
+            \trap(42)->times($times);
+            self::assertSame($isNull, static::$lastData === null);
+            static::$lastData = null;
+        }
     }
 }

--- a/tests/Unit/Client/TrapTest.php
+++ b/tests/Unit/Client/TrapTest.php
@@ -17,13 +17,23 @@ final class TrapTest extends Base
      */
     public function testStackTrace(): void
     {
-        $line = __FILE__ . ':' . __LINE__ and trap();
+        $line = __FILE__ . ':' . __LINE__ and trap()->stackTrace();
 
         $this->assertArrayHasKey('trace', static::$lastData->getValue());
 
         $neededLine = \array_key_first(static::$lastData->getValue()['trace']->getValue());
 
         $this->assertStringContainsString($line, $neededLine);
+    }
+
+    /**
+     * Nothing is dumped if no arguments are passed to {@see trap()}.
+     */
+    public function testEmptyTrapCall(): void
+    {
+        trap();
+
+        self::assertNull(self::$lastData);
     }
 
     /**


### PR DESCRIPTION
More tests
UI StaticFiles middleware caches UI files content
Now `trap()` doesn't print stack trace. Added `trap()->stackTrace()` instead.