### PR TITLE
Fix fast connection closing

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -18,7 +18,7 @@ use Fiber;
 /**
  * @internal
  */
-final class Application implements Processable
+final class Application implements Processable, Cancellable, Destroyable
 {
     /** @var Processable[] */
     private array $processors = [];
@@ -115,6 +115,32 @@ final class Application implements Processable
         }
     }
 
+    public function destroy(): void
+    {
+        foreach ([...$this->servers, ...$this->processors] as $instance) {
+            if ($instance instanceof Destroyable) {
+                $instance->destroy();
+            }
+        }
+
+        $this->servers = [];
+        $this->processors = [];
+        $this->fibers = [];
+    }
+
+    public function cancel(): void
+    {
+        foreach ($this->servers as $server) {
+            $server->cancel();
+        }
+
+        while ($this->fibers !== [] || $this->processors !== []) {
+            echo '.';
+            $this->process();
+            Fiber::getCurrent() === null or Fiber::suspend();
+        }
+    }
+
     /**
      * @param Sender[] $senders
      */
@@ -131,8 +157,9 @@ final class Application implements Processable
 
     private function createServer(SocketServer $config, Inspector $inspector): Server
     {
-        $clientInflector = static function (Client $client, int $id) use ($inspector): Client {
-            // Logger::debug('New client connected %d', $id);
+        $logger = $this->logger;
+        $clientInflector = static function (Client $client, int $id) use ($inspector, $logger): Client {
+            $logger->debug('Client %d connected', $id);
             $inspector->addStream(SocketStream::create($client, $id));
             return $client;
         };

--- a/src/Cancellable.php
+++ b/src/Cancellable.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Buggregator\Trap;
+
+/**
+ * The implementation can be canceled safely.
+ *
+ * @internal
+ */
+interface Cancellable
+{
+    public function cancel(): void;
+}

--- a/src/Client/TrapHandle/Dumper.php
+++ b/src/Client/TrapHandle/Dumper.php
@@ -32,6 +32,7 @@ final class Dumper
 
     public static function dump(mixed $var, string|int|null $label = null, int $depth = 0): mixed
     {
+        /** @psalm-suppress RiskyTruthyFalsyComparison */
         return (self::$handler ??= self::registerHandler())($var, empty($label) ? null : (string)$label, $depth);
     }
 
@@ -72,6 +73,7 @@ final class Dumper
      * @return Closure(mixed, string|null, int): mixed
      *
      * @author Nicolas Grekas <p@tchwork.com>
+     * @psalm-suppress RiskyTruthyFalsyComparison
      */
     private static function registerHandler(): Closure
     {

--- a/src/Command/Run.php
+++ b/src/Command/Run.php
@@ -11,6 +11,7 @@ use Buggregator\Trap\Logger;
 use Buggregator\Trap\Sender;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Command\SignalableCommandInterface;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -24,8 +25,10 @@ use Symfony\Component\Console\Output\OutputInterface;
     name: 'run',
     description: 'Run application',
 )]
-final class Run extends Command
+final class Run extends Command implements SignalableCommandInterface
 {
+    private ?Application $app = null;
+
     public function configure(): void
     {
         $this->addOption('port', 'p', InputOption::VALUE_OPTIONAL, 'Port to listen', 9912);
@@ -54,14 +57,14 @@ final class Run extends Command
 
             $registry = $this->createRegistry($output);
 
-            $app = new Application(
+            $this->app = new Application(
                 [new SocketServer($port)],
                 new Logger($output),
                 senders: $registry->getSenders($senders),
                 withFrontend: $input->getOption('ui') !== false,
             );
 
-            $app->run();
+            $this->app->run();
         } catch (\Throwable $e) {
             if ($output->isVerbose()) {
                 // Write colorful exception (title, message, stacktrace)
@@ -92,5 +95,29 @@ final class Run extends Command
         );
 
         return $registry;
+    }
+
+    public function getSubscribedSignals(): array
+    {
+        $result = [];
+        \defined('SIGINT') and $result[] = \SIGINT;
+        \defined('SIGTERM') and $result[] = \SIGTERM;
+
+        return $result;
+    }
+
+    public function handleSignal(int $signal): void
+    {
+        if (\defined('SIGINT') && $signal === \SIGINT) {
+            // todo may be uncommented if it's possible to switch fibers when signal is received
+            // todo Error: Cannot switch fibers in current execution context
+            // $this->app?->cancel();
+
+            $this->app?->destroy();
+        }
+
+        if (\defined('SIGTERM') && $signal === \SIGTERM) {
+            $this->app?->destroy();
+        }
     }
 }

--- a/src/Destroyable.php
+++ b/src/Destroyable.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Buggregator\Trap;
+
+/**
+ * Should be used to destroy objects and free resources.
+ *
+ * @internal
+ */
+interface Destroyable
+{
+    public function destroy(): void;
+}

--- a/src/Logger.php
+++ b/src/Logger.php
@@ -62,7 +62,9 @@ final class Logger
         $r .= "In \033[3;32m" . $e->getFile() . ':' . $e->getLine() . "\033[0m\n";
         // Print stack trace using gray
         $r .= "Stack trace:\n";
-        $r .= "\033[90m" . $e->getTraceAsString() . "\033[0m\n";
+        // Limit stacktrace to 5 lines
+        $stack = \explode("\n", $e->getTraceAsString());
+        $r .= "\033[90m" . implode("\n", \array_slice($stack, 0, \min(5, \count($stack)))) . "\033[0m\n";
         $r .= "\n";
         $this->echo($r, !$important);
     }

--- a/src/Sender/Console/Renderer/Sentry/Exceptions.php
+++ b/src/Sender/Console/Renderer/Sentry/Exceptions.php
@@ -58,6 +58,8 @@ final class Exceptions
 
     /**
      * Renders the trace of the exception.
+     *
+     * @psalm-suppress RiskyTruthyFalsyComparison
      */
     private static function renderTrace(OutputInterface $output, array $frames, bool $verbose = false): void
     {
@@ -82,6 +84,7 @@ final class Exceptions
             $file = $getValue($frame, 'filename');
             $line = $getValue($frame, 'lineno', null);
             $class = $getValue($frame, 'class');
+            /** @psalm-suppress RiskyTruthyFalsyComparison */
             $class = empty($class) ? '' : $class . '::';
             $function = $getValue($frame, 'function');
 

--- a/src/Sender/Console/Renderer/VarDumper.php
+++ b/src/Sender/Console/Renderer/VarDumper.php
@@ -57,6 +57,9 @@ final class VarDumper implements Renderer
             ) {
             }
 
+            /**
+             * @psalm-suppress RiskyTruthyFalsyComparison
+             */
             public function describe(OutputInterface $output, Data $data, array $context, int $clientId): void
             {
                 Common::renderHeader1($output, 'DUMP');

--- a/src/Socket/Client.php
+++ b/src/Socket/Client.php
@@ -98,6 +98,8 @@ final class Client implements Destroyable
             }
 
             if ($this->toDisconnect && $this->writeQueue === []) {
+                // Wait for the socket buffer to be flushed.
+                (new Timer(0.1))->wait();
                 throw new ClientDisconnected();
             }
             Fiber::suspend();

--- a/src/Socket/Client.php
+++ b/src/Socket/Client.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace Buggregator\Trap\Socket;
 
-use Buggregator\Trap\Socket\Exception\DisconnectClient;
+use Buggregator\Trap\Destroyable;
+use Buggregator\Trap\Socket\Exception\ClientDisconnected;
+use Buggregator\Trap\Support\Timer;
 use Fiber;
 
 /**
@@ -12,7 +14,7 @@ use Fiber;
  *
  * @internal
  */
-final class Client
+final class Client implements Destroyable
 {
      /** @var string[] */
     private array $writeQueue = [];
@@ -33,24 +35,24 @@ final class Client
         $this->setOnClose(fn() => null);
     }
 
-    public function __destruct()
-    {
-        try {
-            \socket_close($this->socket);
-        } catch (\Throwable) {
-            // Do nothing.
-        } finally {
-            /** @psalm-suppress RedundantPropertyInitializationCheck */
-            isset($this->onClose) and ($this->onClose)();
-        }
-    }
-
-    public function close(): void
+    public function destroy(): void
     {
         /** @psalm-suppress RedundantPropertyInitializationCheck */
         isset($this->onClose) and ($this->onClose)();
+        try {
+            \socket_close($this->socket);
+        } catch (\Throwable) {
+            // do nothing
+        }
         // Unlink all closures and free resources.
-        unset($this->onClose, $this->onPayload, $this->readBuffer);
+        unset($this->onClose, $this->onPayload);
+        $this->writeQueue = [];
+        $this->readBuffer = '';
+    }
+
+    public function __destruct()
+    {
+        $this->destroy();
     }
 
     public function disconnect(): void
@@ -96,7 +98,7 @@ final class Client
             }
 
             if ($this->toDisconnect && $this->writeQueue === []) {
-                throw new DisconnectClient();
+                throw new ClientDisconnected();
             }
             Fiber::suspend();
         } while (true);
@@ -126,6 +128,10 @@ final class Client
 
     public function send(string $payload): void
     {
+        if ($this->toDisconnect) {
+            return;
+        }
+
         $this->writeQueue[] = $payload;
     }
 
@@ -147,7 +153,7 @@ final class Client
 
         $this->writeQueue = [];
 
-        $this->toDisconnect and throw new DisconnectClient();
+        $this->toDisconnect and throw new ClientDisconnected();
     }
 
     private function readMessage(): void

--- a/src/Socket/Exception/ClientDisconnected.php
+++ b/src/Socket/Exception/ClientDisconnected.php
@@ -7,6 +7,6 @@ namespace Buggregator\Trap\Socket\Exception;
 /**
  * @internal
  */
-class DisconnectClient extends \RuntimeException
+class ClientDisconnected extends \RuntimeException
 {
 }

--- a/src/Socket/Exception/ServerStopped.php
+++ b/src/Socket/Exception/ServerStopped.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Buggregator\Trap\Socket\Exception;
+
+/**
+ * @internal
+ */
+class ServerStopped extends \RuntimeException
+{
+}

--- a/src/Socket/Server.php
+++ b/src/Socket/Server.php
@@ -95,6 +95,7 @@ final class Server implements Processable, Cancellable, Destroyable
         while (!$this->cancelled and false !== ($socket = \socket_accept($this->socket))) {
             $client = null;
             try {
+                /** @psalm-suppress MixedArgument */
                 $client = Client::init($socket, $this->payloadSize);
                 $key = (int)\array_key_last($this->clients) + 1;
                 $this->clients[$key] = $client;


### PR DESCRIPTION
## What was changed

Added a constant delay of 100ms before an instant disconnect.
Run command now consumes signals
Added Cancellable and Destroyable interfaces

## Why?

In some cases, the connection to the client closes too quickly. The client doesn't have time to receive all the content.

This problem could have been solved by removing this fragment:

https://github.com/buggregator/trap/blob/929ce1f3d520e66a1e567f9def83020c6f099845/src/Socket/Server.php#L40-L41

but the convenience of restarting the server is still important.
