### PR TITLE
Add compatibility with Symfony Console 7.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -60,7 +60,7 @@
         "nyholm/psr7": "^1.8",
         "php-http/message": "^1.15",
         "psr/http-message": "^1.1 || ^2",
-        "symfony/console": "^5.4 || ^6 || ^7",
+        "symfony/console": "^6.4 || ^7",
         "symfony/var-dumper": "^6.3 || ^7"
     },
     "require-dev": {

--- a/src/Command/Run.php
+++ b/src/Command/Run.php
@@ -107,7 +107,7 @@ final class Run extends Command implements SignalableCommandInterface
         return $result;
     }
 
-    public function handleSignal(int $signal): int|false
+    public function handleSignal(int $signal, int|false $previousExitCode = 0): int|false
     {
         if (\defined('SIGINT') && $signal === \SIGINT) {
             if ($this->cancelled) {


### PR DESCRIPTION
## What was changed

Added compatibility with Symfony Console 7.0. There was an error before these changes:

```
PHP Fatal error:  Declaration of Buggregator\Trap\Command\Run::handleSignal(int $signal): int|false must be compatible with Symfony\Component\Console\Command\SignalableCommandInterface::handleSignal(int $signal, int|false $previousExitCode = 0): int|false in ... src/Command/Run.php on line 110
```

Removed support for symfony/console 5.x and 6.0 because the method in the interface has a void return type:
https://github.com/symfony/console/blob/v5.4.34/Command/SignalableCommandInterface.php#L29
https://github.com/symfony/console/blob/v6.0.19/Command/SignalableCommandInterface.php#L29

