### PR TITLE
Add method `trap()->return()`

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,9 +125,14 @@ This command will start the Trap server, ready to receive any debug messages. On
 Then just call the `trap()` function in your code:
 
 ```php
-trap(); // dump the current stack trace
-trap($var)->depth(4); // dump a variable with a depth limit
-trap($var, foo: $far, bar: $bar); // dump a named variables sequence
+// dump the current stack trace
+trap()->stackTrace();
+// dump a variable with a depth limit
+trap($var)->depth(4);
+ // dump a named variables sequence
+trap($var, foo: $far, bar: $bar);
+// dump a variable and return it
+$responder->respond(trap($response)->return()); 
 ```
 
 > **Note**:

--- a/src/Info.php
+++ b/src/Info.php
@@ -10,7 +10,7 @@ namespace Buggregator\Trap;
 class Info
 {
     public const NAME = 'Buggregator Trap';
-    public const VERSION = '1.3.3';
+    public const VERSION = '1.4.0';
     public const LOGO_CLI_COLOR = <<<CONSOLE
         \e[44;97;1m                                    \e[0m
         \e[44;97;1m      ▄█▀                  ▀█▄      \e[0m

--- a/tests/Unit/Client/TrapTest.php
+++ b/tests/Unit/Client/TrapTest.php
@@ -59,6 +59,21 @@ final class TrapTest extends Base
         }
     }
 
+    public function testReturn(): void
+    {
+        $this->assertSame(42, \trap(42)->return());
+        $this->assertSame(42, \trap(named: 42)->return());
+        $this->assertSame(42, \trap(named: 42)->return('bad-name'));
+        $this->assertSame(42, \trap(42, 43)->return());
+        $this->assertSame(42, \trap(int: 42, foo: 'bar')->return('int'));
+        $this->assertSame(42, \trap(int: 42, foo: 'bar')->return(0));
+        $this->assertSame('foo', \trap(...['0' => 'foo', 42 => 90])->return());
+        $this->assertNull(\trap(null)->return());
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->assertSame(42, \trap(42, 43)->return(10));
+    }
+
     public static function provideTrapTimes(): iterable
     {
         yield 'no limit' => [0, [false, false, false, false, false]];


### PR DESCRIPTION
## What was changed

Add method `trap()->return()`
```php
    /**
     * Send the dump if possible and then return the dumped value immediately.
     *
     * @param int|string $key Position in the value sequence (0-based) or name of the named argument.
     *
     * ```php
     * trap(42)->return(); // 42
     * trap(count: 42, value: 90)->return('value'); // 90
     * trap(foo: 'bar')->return(0); // 'bar'
     * trap()->return(); // exception
     * ```
     */
    public function return(int|string $key = 0): mixed
```

## Why?

Sometimes you have to dump the argument value, which is calculated and not stored in a variable. In such cases, you have to extract the code into a separate variable, which is not very convenient. It's easier to wrap the value with `trap(  <value>  )->return()`.

## Checklist

- [x] Tests
- [x] Documentation