### PR TITLE
Added the ability to run the program listening on multiple ports

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,13 +141,20 @@ $responder->respond(trap($response)->return());
 
 ### Default port
 
-By default, the Trap server operates on port `9912`. However, if you wish to utilize a different port, you can easily
-make this adjustment using the `-p` option.
-
-For example, to switch to port 8000, you would use the following command:
+Trap automatically recognizes the type of traffic.
+Therefore, there is no need to open separate ports for different protocols.
+By default, it operates on port `9912`.
+However, if you wish to utilize a different port, you can easily make this adjustment using the `-p` option:
 
 ```bash
-vendor/bin/trap -p 8000
+vendor/bin/trap -p8000
+```
+
+Sometimes, it's convenient to run Trap on the same ports that [Buggregator](https://github.com/buggregator/server)
+uses by default. Well, that's also possible:
+
+```bash
+vendor/bin/trap -p1025 -p9912 -p9913 -p8000
 ```
 
 ### Choosing Your Senders

--- a/src/Command/Run.php
+++ b/src/Command/Run.php
@@ -63,11 +63,18 @@ final class Run extends Command implements SignalableCommandInterface
              * @var SocketServer[] $servers
              */
             $servers = [];
-            foreach ($input->getOption('port') ?: [9912] as $port) {
+            $ports = $input->getOption('port') ?: [9912];
+            \assert(\is_array($ports));
+            foreach ($ports as $port) {
+                \assert(\is_scalar($port));
                 \is_numeric($port) or throw new \InvalidArgumentException(
-                    \sprintf('Invalid port `%s`. It must be a number.', $port),
+                    \sprintf('Invalid port `%s`. It must be a number.', (string)$port),
                 );
-                $servers[] = new SocketServer((int)$port);
+                $port = (int)$port;
+                $port > 0 && $port < 65536 or throw new \InvalidArgumentException(
+                    \sprintf('Invalid port `%s`. It must be in range 1-65535.', $port),
+                );
+                $servers[] = new SocketServer($port);
             }
 
             /** @var non-empty-string[] $senders */


### PR DESCRIPTION
## What was changed
The `--port` (`-p`) parameter is a plural value

## Why?

Although Trap is capable of identifying the type of traffic, launching to listen on multiple ports can be convenient to avoid making changes to configuration files.

