### PR TITLE
ci: add missing phive repository files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /.*/
+!/.phive/
 !/.github/
 /runtime/
 /vendor/

--- a/.phive/.gitignore
+++ b/.phive/.gitignore
@@ -1,0 +1,3 @@
+*
+!.gitignore
+!phars.xml

--- a/.phive/phars.xml
+++ b/.phive/phars.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phive xmlns="https://phar.io/phive">
+  <phar name="composer-normalize" version="^2.42.0" installed="2.42.0" location="./.phive/composer-normalize" copy="false"/>
+  <phar name="composer-require-checker" version="^4.10.0" installed="4.10.0" location="./.phive/composer-require-checker" copy="false"/>
+  <phar name="box-project/box" version="^4.6.1" installed="4.6.1" location="./.phive/box" copy="false"/>
+</phive>


### PR DESCRIPTION
Because of root .gitignore `/.*/` rule, there were missing files in .phive folder, which raised error, when using such commands:

```bash
make lint-composer
make phive
make lint-deps
```
