### PR TITLE
ci: add composer-require-checker file to support local dep linting

### DIFF
--- a/composer-require-checker.json
+++ b/composer-require-checker.json
@@ -1,0 +1,22 @@
+{
+    "symbol-whitelist": [
+        "Buggregator\\Trap\\Test\\Proto\\Message_Foo",
+        "Buggregator\\Trap\\Test\\Proto\\Message_Header",
+        "Buggregator\\Trap\\Test\\Proto\\Message_Metadata",
+        "Google\\Protobuf\\Internal\\Descriptor",
+        "Google\\Protobuf\\Internal\\DescriptorPool",
+        "Google\\Protobuf\\Internal\\GPBType",
+        "Google\\Protobuf\\Internal\\GPBUtil",
+        "Google\\Protobuf\\Internal\\MapField",
+        "Google\\Protobuf\\Internal\\Message",
+        "Google\\Protobuf\\Internal\\RepeatedField",
+        "LIBXML_NOERROR",
+        "SIGINT",
+        "SIGTERM",
+        "simplexml_load_string",
+        "Symfony\\Component\\HttpFoundation\\Request",
+        "Symfony\\Component\\HttpFoundation\\RequestStack",
+        "Symfony\\Component\\HttpKernel\\Debug\\FileLinkFormatter",
+        "Twig\\Template"
+    ]
+}

--- a/composer.json
+++ b/composer.json
@@ -43,6 +43,7 @@
     ],
     "require": {
         "php": ">=8.1",
+        "ext-filter": "*",
         "ext-sockets": "*",
         "clue/stream-filter": "^1.6",
         "nunomaduro/termwind": "^1.15 || ^2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "0c3f34aa393f679587daf5ad472833fb",
+    "content-hash": "c63c5b3a7fb9968c9a33be396d75e976",
     "packages": [
         {
             "name": "clue/stream-filter",
@@ -6521,6 +6521,7 @@
     "prefer-lowest": false,
     "platform": {
         "php": ">=8.1",
+        "ext-filter": "*",
         "ext-sockets": "*"
     },
     "platform-dev": [],


### PR DESCRIPTION
## What was changed

Added missing `composer-require-checker.json` file

## Why?

This tool helps to check for external dependencies, that are not listed as required in `composer.json` file.