### PR TITLE
Add `trap()->code()` sugar

### DIFF
--- a/src/Client/TrapHandle.php
+++ b/src/Client/TrapHandle.php
@@ -176,9 +176,16 @@ final class TrapHandle
      * Code syntax highlighting.
      *
      * Adds `language` data context to denote the passed data as source code.
-     * In this case, Buggragator will perform code highlighting.
+     * In this case, Buggregator will perform code highlighting.
      *
      * Note: it equals to `trap()->context(language: $syntax);`
+     *
+     * ```php
+     * trap(
+     *   index: $indexCode,
+     *   controller: $controllerCode,
+     * )->code('php');
+     * ```
      *
      * @param non-empty-string $syntax The name of the programming language
      */

--- a/src/Client/TrapHandle.php
+++ b/src/Client/TrapHandle.php
@@ -172,9 +172,13 @@ final class TrapHandle
         return $this;
     }
 
-    public function highlight(string $language): self
+    /**
+     * Code highlighting.
+     * Will call the context method{@see context()} and pass the language parameter
+     */
+    public function code(string $syntax): self
     {
-        return $this->context(language: $language);
+        return $this->context(language: $syntax);
     }
 
     public function __destruct()

--- a/src/Client/TrapHandle.php
+++ b/src/Client/TrapHandle.php
@@ -173,8 +173,14 @@ final class TrapHandle
     }
 
     /**
-     * Code highlighting.
-     * Will call the context method{@see context()} and pass the language parameter
+     * Code syntax highlighting.
+     *
+     * Adds `language` data context to denote the passed data as source code.
+     * In this case, Buggragator will perform code highlighting.
+     *
+     * Note: it equals to `trap()->context(language: $syntax);`
+     *
+     * @param non-empty-string $syntax The name of the programming language
      */
     public function code(string $syntax): self
     {

--- a/src/Client/TrapHandle.php
+++ b/src/Client/TrapHandle.php
@@ -172,6 +172,11 @@ final class TrapHandle
         return $this;
     }
 
+    public function highlight(string $language): self
+    {
+        return $this->context(language: $language);
+    }
+
     public function __destruct()
     {
         $this->haveToSend() and $this->sendDump();

--- a/tests/Unit/Client/TrapTest.php
+++ b/tests/Unit/Client/TrapTest.php
@@ -47,6 +47,13 @@ final class TrapTest extends Base
         self::assertSame(['foo' => 'new', 'bar' => 'bar-context'], self::$lastData->getContext());
     }
 
+    public function testCodeHighlight(): void
+    {
+        trap('test-value')->code('php');
+
+        self::assertSame(['language' => 'php'], self::$lastData->getContext());
+    }
+
     /**
      * Check the first line of dumped stacktrace string contains right file and line.
      */


### PR DESCRIPTION
## What was changed
Nothing changes, just sugar

Before 
```php
trap()->context(language: 'php')
```
After
```php
trap()->code('php')
```

## Why?

The presence of a method will give you an immediate understanding of the presence of this feature even without referring to the documentation, it will be easier to remember, and it will be immediately clear what’s what

## Checklist

- Tested
  - [x] Tested manually
  - [x] Unit tests added
- [ ] Documentation
