### PR TITLE
ci: to not include version prefix

### DIFF
--- a/.github/.release-please-config.json
+++ b/.github/.release-please-config.json
@@ -8,6 +8,7 @@
         }
     },
     "include-component-in-tag": false,
+    "include-v-in-tag": false,
     "changelog-type": "github",
     "changelog-sections": [
         {


### PR DESCRIPTION
Do not include v prefix in release versions

Example:
v1.8.0 -> 1.8.0