### PR TITLE
CI: separate pest config and isolate pest from unit tests

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -129,11 +129,11 @@ jobs:
         with:
           dependencies: ${{ matrix.dependencies }}
 
-      - name: 🧪 Run unit tests using pestphp/pest
+      - name: 🧪 Run unit tests using phpunit/phpunit
         run: composer test
 
-      - name: 🧪 Run tests that require separate process using phpunit/phpunit
-        run: composer test:sep
+      - name: 🧪 Run arch tests using pestphp/pest
+        run: composer test:arch
 
   compile-phar:
     timeout-minutes: 4

--- a/composer.json
+++ b/composer.json
@@ -128,15 +128,12 @@
         "stan:ci": "phpstan analyse --memory-limit=2G --error-format=github",
         "test": [
             "@putenv XDEBUG_MODE=coverage",
-            "pest --exclude-group=phpunit-only --color=always"
+            "phpunit --color=always"
         ],
+        "test:arch": "pest --color=always --configuration pest.xml.dist",
         "test:cc": [
             "@putenv XDEBUG_MODE=coverage",
-            "pest --coverage --coverage-clover=.build/phpunit/logs/clover.xml --exclude-group=phpunit-only --color=always"
-        ],
-        "test:sep": [
-            "@putenv XDEBUG_MODE=coverage",
-            "phpunit --group=phpunit-only --color=always --exclude-testsuite=Arch"
+            "phpunit --coverage-clover=.build/phpunit/logs/clover.xml --color=always"
         ]
     }
 }

--- a/pest.xml.dist
+++ b/pest.xml.dist
@@ -14,20 +14,10 @@
         <bootstrap class="Ergebnis\PHPUnit\SlowTestDetector\Extension"/>
     </extensions>
     <testsuites>
-        <testsuite name="Unit">
-            <directory>tests/Unit</directory>
+        <testsuite name="Arch">
+            <directory>tests/Arch</directory>
         </testsuite>
     </testsuites>
-    <coverage>
-        <report>
-            <html outputDirectory=".build/coverage"/>
-            <text outputFile=".build/coverage.txt"/>
-            <clover outputFile=".build/logs/clover.xml"/>
-        </report>
-    </coverage>
-    <logging>
-        <junit outputFile=".build/report.junit.xml"/>
-    </logging>
     <source>
         <include>
             <directory>src</directory>

--- a/tests/Unit/Client/FunctionTrapTest.php
+++ b/tests/Unit/Client/FunctionTrapTest.php
@@ -4,14 +4,12 @@ declare(strict_types=1);
 
 namespace Buggregator\Trap\Tests\Unit\Client;
 
-use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\RunInSeparateProcess;
 use PHPUnit\Framework\TestCase;
 
 final class FunctionTrapTest extends TestCase
 {
     #[RunInSeparateProcess]
-    #[Group('phpunit-only')]
     public function testLeak(): void
     {
         $object = new \stdClass();

--- a/tests/Unit/Client/TrTest.php
+++ b/tests/Unit/Client/TrTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Buggregator\Trap\Tests\Unit\Client;
 
 use Buggregator\Trap\Client\TrapHandle\Dumper;
-use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\RunInSeparateProcess;
 use Symfony\Component\VarDumper\Dumper\DataDumperInterface;
 
@@ -21,7 +20,6 @@ final class TrTest extends Base
      * Check the stacktrace contains three items and it begins with the right function name.
      */
     #[RunInSeparateProcess]
-    #[Group('phpunit-only')]
     public function testTrAsStackTrace(): void
     {
         tr();


### PR DESCRIPTION
## What was changed

Pest is used for arch tests only. It uses separated config file to not to break phpunit

## Why?

pest doesn't work well but we need to have arch tests

## Checklist

- Closes #112
- Tested
