### PR TITLE
Add ability to process HTTP events and UI on the same port

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ And that's it. Trap is [ready to go](#usage).
 Buggregator Trap provides a toolkit for use in your code. Firstly, just having Buggregator Trap in your
 package enhances the capabilities of Symfony Var-Dumper.
 
-If you've already worked with google/protobuf, you probably know how unpleasant it can be.
+If you've already worked with `google/protobuf`, you probably know how unpleasant it can be.
 Now let's compare the dumps of protobuf-message: on the left (with trap) and on the right (without trap).
 
 ![trap-proto-diff](https://github.com/buggregator/trap/assets/4152481/30662429-809e-422a-83c6-61d7d2788b18)
@@ -171,18 +171,11 @@ function handle($input) {
 
 Trap automatically recognizes the type of traffic.
 Therefore, there is no need to open separate ports for different protocols.
-By default, it operates on port `9912`.
+By default, it operates on the same ports as the Buggregator Server: `9912`, `9913`, `1025`, and `8000`.
 However, if you wish to utilize a different port, you can easily make this adjustment using the `-p` option:
 
 ```bash
-vendor/bin/trap -p8000
-```
-
-Sometimes, it's convenient to run Trap on the same ports that [Buggregator](https://github.com/buggregator/server)
-uses by default. Well, that's also possible:
-
-```bash
-vendor/bin/trap -p1025 -p9912 -p9913 -p8000 --ui=8080
+vendor/bin/trap -p9912 --ui=8000
 ```
 
 Environment variables can also be used to set endpoints:

--- a/psalm.xml
+++ b/psalm.xml
@@ -10,6 +10,11 @@
     <issueHandlers>
         <RedundantConditionGivenDocblockType errorLevel="suppress"/>
         <RedundantCastGivenDocblockType errorLevel="suppress"/>
+        <PropertyNotSetInConstructor errorLevel="suppress">
+            <errorLevel type="suppress">
+                <directory name="src/Command"/>
+            </errorLevel>
+        </PropertyNotSetInConstructor>
     </issueHandlers>
     <projectFiles>
         <directory name="src"/>

--- a/src/Application.php
+++ b/src/Application.php
@@ -55,7 +55,7 @@ final class Application implements Processable, Cancellable, Destroyable
 
         // Frontend
         $feConfig = $this->container->get(FrontendConfig::class);
-        $feSeparated = $withFrontend && !\in_array(
+        $feSeparated = !\in_array(
             $feConfig->port,
             \array_map(static fn(SocketServer $item): ?int => $item->type === 'tcp' ? $item->port : null, $map, ),
             true,
@@ -80,7 +80,8 @@ final class Application implements Processable, Cancellable, Destroyable
         ]);
         $this->processors[] = $inspector;
 
-        if (!$feSeparated) {
+
+        if ($withFrontend && !$feSeparated) {
             $inspectorWithFrontend = $container->make(Inspector::class, [
                 new Traffic\Dispatcher\VarDumper(),
                 new Traffic\Dispatcher\Http(
@@ -103,7 +104,7 @@ final class Application implements Processable, Cancellable, Destroyable
         $this->configureFileObserver();
 
         foreach ($map as $config) {
-            !$feSeparated && $config->type === 'tcp' && $config->port === $feConfig->port
+            $withFrontend && !$feSeparated && $config->type === 'tcp' && $config->port === $feConfig->port
                 ? $this->prepareServerFiber($config, $inspectorWithFrontend, $this->logger)
                 : $this->prepareServerFiber($config, $inspector, $this->logger);
         }

--- a/src/Application.php
+++ b/src/Application.php
@@ -53,7 +53,16 @@ final class Application implements Processable, Cancellable, Destroyable
         $this->buffer = new Buffer(bufferSize: 10485760, timer: 0.1);
         $this->container->set($this->buffer);
 
-        $inspector = $container->make(Inspector::class, [
+        // Frontend
+        $feConfig = $this->container->get(FrontendConfig::class);
+        $feSeparated = $withFrontend && !\in_array(
+            $feConfig->port,
+            \array_map(static fn(SocketServer $item): ?int => $item->type === 'tcp' ? $item->port : null, $map, ),
+            true,
+        );
+        $withFrontend and $this->configureFrontend($feSeparated);
+
+        $inspectorWithFrontend = $inspector = $container->make(Inspector::class, [
             // new Traffic\Dispatcher\WebSocket(),
             new Traffic\Dispatcher\VarDumper(),
             new Traffic\Dispatcher\Http(
@@ -71,11 +80,32 @@ final class Application implements Processable, Cancellable, Destroyable
         ]);
         $this->processors[] = $inspector;
 
-        $withFrontend and $this->configureFrontend();
+        if (!$feSeparated) {
+            $inspectorWithFrontend = $container->make(Inspector::class, [
+                new Traffic\Dispatcher\VarDumper(),
+                new Traffic\Dispatcher\Http(
+                    [
+                        $this->container->get(Sender\Frontend\Http\Pipeline::class),
+                        $this->container->get(Middleware\Resources::class),
+                        $this->container->get(Middleware\DebugPage::class),
+                        $this->container->get(Middleware\RayRequestDump::class),
+                        $this->container->get(Middleware\SentryTrap::class),
+                        $this->container->get(Middleware\XHProfTrap::class),
+                    ],
+                    [$this->container->get(Sender\Frontend\Http\RequestHandler::class)],
+                ),
+                new Traffic\Dispatcher\Smtp(),
+                new Traffic\Dispatcher\Monolog(),
+            ]);
+            $this->processors[] = $inspectorWithFrontend;
+        }
+
         $this->configureFileObserver();
 
         foreach ($map as $config) {
-            $this->prepareServerFiber($config, $inspector, $this->logger);
+            !$feSeparated && $config->type === 'tcp' && $config->port === $feConfig->port
+                ? $this->prepareServerFiber($config, $inspectorWithFrontend, $this->logger)
+                : $this->prepareServerFiber($config, $inspector, $this->logger);
         }
     }
 
@@ -175,18 +205,22 @@ final class Application implements Processable, Cancellable, Destroyable
         });
     }
 
-    public function configureFrontend(): void
+    public function configureFrontend(bool $separated): void
     {
         $this->processors[] = $this->senders[] = $wsSender = Sender\FrontendSender::create($this->logger);
-        $this->container->set($wsSender->getEventStorage(), Sender\Frontend\EventStorage::class);
+        $this->container->set($wsSender);
+        $this->container->set($wsSender->getEventStorage());
+        $this->container->set($wsSender->getConnectionPool());
+
+        if (!$separated) {
+            return;
+        }
 
         // Separated port
         $inspector = $this->container->make(Inspector::class, [
             new Traffic\Dispatcher\Http(
-                [
-                    new Sender\Frontend\Http\Pipeline($this->logger, $wsSender),
-                ],
-                [new Sender\Frontend\Http\RequestHandler($wsSender->getConnectionPool())],
+                [$this->container->get(Sender\Frontend\Http\Pipeline::class)],
+                [$this->container->get(Sender\Frontend\Http\RequestHandler::class)],
                 silentMode: true,
             ),
         ]);

--- a/src/Command/Run.php
+++ b/src/Command/Run.php
@@ -63,7 +63,7 @@ final class Run extends Command implements SignalableCommandInterface
         $config = $container->get(TcpPorts::class);
 
         $servers = [];
-        $ports = $config->ports ?: [9912];
+        $ports = $config->ports ?: [1025, 8000, 9912, 9913];
         /** @var scalar $port */
         foreach ($ports as $port) {
             \is_numeric($port) or throw new \InvalidArgumentException(

--- a/src/Handler/Http/Handler/Fallback.php
+++ b/src/Handler/Http/Handler/Fallback.php
@@ -82,7 +82,9 @@ final class Fallback implements RequestHandler
             $streamClient->disconnect();
         }
 
-        if (isset($response) && $response->hasHeader(FrontendPipeline::FRONTEND_HEADER)) {
+        /** @var mixed $response */
+        $response ??= null;
+        if ($response instanceof ResponseInterface && $response->hasHeader(FrontendPipeline::FRONTEND_HEADER)) {
             return;
         }
 

--- a/src/Handler/Http/Handler/Fallback.php
+++ b/src/Handler/Http/Handler/Fallback.php
@@ -9,6 +9,7 @@ use Buggregator\Trap\Handler\Http\Middleware;
 use Buggregator\Trap\Handler\Http\RequestHandler;
 use Buggregator\Trap\Handler\Pipeline;
 use Buggregator\Trap\Proto\Frame;
+use Buggregator\Trap\Sender\Frontend\Http\Pipeline as FrontendPipeline;
 use Buggregator\Trap\Traffic\StreamClient;
 use Nyholm\Psr7\Response;
 use Psr\Http\Message\ResponseInterface;
@@ -79,6 +80,10 @@ final class Fallback implements RequestHandler
             HttpEmitter::emit($streamClient, new Response(500));
         } finally {
             $streamClient->disconnect();
+        }
+
+        if (isset($response) && $response->hasHeader(FrontendPipeline::FRONTEND_HEADER)) {
+            return;
         }
 
         if (!$gotFrame) {

--- a/src/Sender/Frontend/Http/Pipeline.php
+++ b/src/Sender/Frontend/Http/Pipeline.php
@@ -6,6 +6,7 @@ namespace Buggregator\Trap\Sender\Frontend\Http;
 
 use Buggregator\Trap\Handler\Http\Middleware;
 use Buggregator\Trap\Handler\Pipeline as MiddlewaresPipeline;
+use Buggregator\Trap\Info;
 use Buggregator\Trap\Logger;
 use Nyholm\Psr7\Response;
 use Psr\Http\Message\ResponseInterface;
@@ -19,6 +20,8 @@ use Psr\Http\Message\ServerRequestInterface;
  */
 final class Pipeline implements Middleware
 {
+    public const FRONTEND_HEADER = 'X-Trap-Frontend';
+
     /** @var MiddlewaresPipeline<Middleware, ResponseInterface> */
     private MiddlewaresPipeline $pipeline;
 
@@ -48,6 +51,6 @@ final class Pipeline implements Middleware
 
         return $response->getStatusCode() === 404
             ? $next($request)
-            : $response;
+            : $response->withHeader(self::FRONTEND_HEADER, Info::version());
     }
 }

--- a/src/Sender/Frontend/Http/Pipeline.php
+++ b/src/Sender/Frontend/Http/Pipeline.php
@@ -30,6 +30,7 @@ final class Pipeline implements Middleware
         \Buggregator\Trap\Sender\FrontendSender $wsSender,
     ) {
         // Build pipeline of handlers.
+        /** @var MiddlewaresPipeline<Middleware, ResponseInterface> */
         $this->pipeline = MiddlewaresPipeline::build(
             [
                 new Cors(),

--- a/src/Sender/Frontend/Http/Pipeline.php
+++ b/src/Sender/Frontend/Http/Pipeline.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Buggregator\Trap\Sender\Frontend\Http;
+
+use Buggregator\Trap\Handler\Http\Middleware;
+use Buggregator\Trap\Handler\Pipeline as MiddlewaresPipeline;
+use Buggregator\Trap\Logger;
+use Nyholm\Psr7\Response;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+/**
+ * Full Frontend HTTP pipeline as single middleware.
+ *
+ * @internal
+ * @psalm-internal Buggregator\Trap
+ */
+final class Pipeline implements Middleware
+{
+    /** @var MiddlewaresPipeline<Middleware, ResponseInterface> */
+    private MiddlewaresPipeline $pipeline;
+
+    public function __construct(
+        Logger $logger,
+        \Buggregator\Trap\Sender\FrontendSender $wsSender,
+    ) {
+        // Build pipeline of handlers.
+        $this->pipeline = MiddlewaresPipeline::build(
+            [
+                new Cors(),
+                new StaticFiles(),
+                new EventAssets($logger, $wsSender->getEventStorage()),
+                new Router($logger, $wsSender->getEventStorage()),
+            ],
+            /** @see Middleware::handle() */
+            'handle',
+            static fn(): ResponseInterface => new Response(404),
+            ResponseInterface::class,
+        );
+    }
+
+    public function handle(ServerRequestInterface $request, callable $next): ResponseInterface
+    {
+        /** @var ResponseInterface $response */
+        $response = ($this->pipeline)($request);
+
+        return $response->getStatusCode() === 404
+            ? $next($request)
+            : $response;
+    }
+}

--- a/src/Service/Container.php
+++ b/src/Service/Container.php
@@ -88,7 +88,7 @@ final class Container implements ContainerInterface, Destroyable
             try {
                 $result = $this->injector->make($class, \array_merge((array) $binding, $arguments));
             } catch (\Throwable $e) {
-                throw new class("Unable to create object of class $class.", previous: $e, ) extends \RuntimeException implements NotFoundExceptionInterface {};
+                throw new class("Unable to create object of class $class.", previous: $e) extends \RuntimeException implements NotFoundExceptionInterface {};
             }
         }
 


### PR DESCRIPTION
## What was changed

- Add ability to process HTTP events and UI on the same port
- Default open ports now the same as in Buggregator Server: `1025`, `8000`, `9912` and `9913`

## Why?

To use same port for UI and data collection and to be interchangeable with the Buggregator Server

## Checklist

- Closes #121 
- Tested
  - [x] Tested manually
  - [ ] Unit tests added
- [ ] Documentation <!--- Remove if not needed -->
