### PR TITLE
Better HTTP/SMTP Multipart parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,11 +27,11 @@ Trap includes:
 
 **Table of content:**
 
-* [Installation](#installation)
-* [Overview](#overview)
-* [Usage](#usage)
-* [Contributing](#contributing)
-* [License](#license)
+- [Installation](#installation)
+- [Overview](#overview)
+- [Usage](#usage)
+- [Contributing](#contributing)
+- [License](#license)
 
 ## Installation
 

--- a/src/Traffic/Message/Multipart/Part.php
+++ b/src/Traffic/Message/Multipart/Part.php
@@ -28,26 +28,23 @@ abstract class Part implements \JsonSerializable
      */
     public static function create(array $headers): Part
     {
-        /**
-         * Check Content-Disposition header
-         *
-         * @var string $contentDisposition
-         */
-        $contentDisposition = self::findHeader($headers, 'Content-Disposition')[0]
-            ?? throw new \RuntimeException('Missing Content-Disposition header.');
-        if ($contentDisposition === '') {
-            throw new \RuntimeException('Missing Content-Disposition header, can\'t be empty');
+        $contentDisposition = self::findHeader($headers, 'Content-Disposition')[0] ?? null;
+
+        $name = $fileName = null;
+        if ((string) $contentDisposition !== '') {
+            // Get field name and file name
+            $name = \preg_match('/\bname=(?:(?<a>[^" ;,]++)|"(?<b>[^"]++)")/', $contentDisposition, $matches) === 1
+                ? ($matches['a'] ?: $matches['b'])
+                : null;
+
+            // Decode file name
+            $fileName = \preg_match(
+                '/\bfilename=(?:(?<a>[^" ;,]++)|"(?<b>[^"]++)")/',
+                $contentDisposition,
+                $matches,
+            ) === 1 ? ($matches['a'] ?: $matches['b']) : null;
         }
 
-        // Get field name and file name
-        $name = \preg_match('/\bname=(?:(?<a>[^" ;,]++)|"(?<b>[^"]++)")/', $contentDisposition, $matches) === 1
-            ? ($matches['a'] ?: $matches['b'])
-            : null;
-
-        // Decode file name
-        $fileName = \preg_match('/\bfilename=(?:(?<a>[^" ;,]++)|"(?<b>[^"]++)")/', $contentDisposition, $matches) === 1
-            ? ($matches['a'] ?: $matches['b'])
-            : null;
         $fileName = $fileName !== null ? \html_entity_decode($fileName) : null;
         $isFile = (string) $fileName !== ''
             || \preg_match('/text\\/.++/', self::findHeader($headers, 'Content-Type')[0] ?? 'text/plain') !== 1;

--- a/src/Traffic/Parser/Http.php
+++ b/src/Traffic/Parser/Http.php
@@ -224,7 +224,7 @@ final class Http
         $contentType = $request->getHeaderLine('Content-Type');
         return match (true) {
             $contentType === 'application/x-www-form-urlencoded' => self::parseUrlEncodedBody($request),
-            \str_contains($contentType, 'multipart/form-data') => $this->processMultipartForm($request),
+            \str_contains($contentType, 'multipart/') => $this->processMultipartForm($request),
             default => $request,
         };
     }

--- a/src/Traffic/Parser/MultipartType.php
+++ b/src/Traffic/Parser/MultipartType.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Buggregator\Trap\Traffic\Parser;
+
+/**
+ * @internal
+ */
+enum MultipartType: string
+{
+    case Mixed = 'mixed';
+    case Alternative = 'alternative';
+    case Digest = 'digest';
+    case Parallel = 'parallel';
+    case FormData = 'form-data';
+    case Report = 'report';
+    case Signed = 'signed';
+    case Encrypted = 'encrypted';
+    case Related = 'related';
+    case Other = 'other';
+
+    public static function fromHeaderLine(string $headerLine): self
+    {
+        $type = \explode(';', $headerLine, 2)[0];
+        return match ($type) {
+            'multipart/mixed' => self::Mixed,
+            'multipart/alternative' => self::Alternative,
+            'multipart/digest' => self::Digest,
+            'multipart/parallel' => self::Parallel,
+            'multipart/form-data' => self::FormData,
+            'multipart/report' => self::Report,
+            'multipart/signed' => self::Signed,
+            'multipart/encrypted' => self::Encrypted,
+            'multipart/related' => self::Related,
+            default => self::Other,
+        };
+    }
+}


### PR DESCRIPTION
## What was changed

Fix parsing for `multipart/mixed` data when:
- There is trailing dot (`.`) in raw data. In this case connection was frozen.
- A multipart field doesn't contain `Content-Disposition` header. In this case parser just failed and zero chunks was parsed.

Related with https://github.com/buggregator/frontend/issues/178