### PR TITLE
Separate polling intervals for sockets

### DIFF
--- a/psalm.xml
+++ b/psalm.xml
@@ -6,6 +6,7 @@
        findUnusedBaselineEntry="false"
        findUnusedCode="false"
        errorBaseline="psalm-baseline.xml"
+       phpVersion="8.1"
 >
     <issueHandlers>
         <RedundantConditionGivenDocblockType errorLevel="suppress"/>

--- a/src/Application.php
+++ b/src/Application.php
@@ -256,6 +256,7 @@ final class Application implements Processable, Cancellable, Destroyable
         return Server::init(
             $config->port,
             payloadSize: 524_288,
+            acceptPeriod: .001,
             clientInflector: $clientInflector,
             logger: $this->logger,
         );

--- a/src/Sender/Console/Renderer/Sentry/Exceptions.php
+++ b/src/Sender/Console/Renderer/Sentry/Exceptions.php
@@ -87,26 +87,27 @@ final class Exceptions
             $class = empty($class) ? '' : $class . '::';
             $function = $getValue($frame, 'function');
 
-            $renderer = static fn() => $output->writeln(
-                \sprintf(
-                    "<fg=gray>%s</><fg=white;options=bold>%s<fg=yellow>%s</>\n%s<fg=yellow>%s</><fg=gray>%s()</>",
-                    \str_pad("#$i", $numPad, ' '),
-                    (string) $file,
-                    $line !== '' ? ":$line" : '',
-                    \str_repeat(' ', $numPad),
-                    $class,
-                    (string) $function,
-                ),
+            $renderedLine = \sprintf(
+                "<fg=gray>%s</><fg=white;options=bold>%s<fg=yellow>%s</>\n%s<fg=yellow>%s</><fg=gray>%s()</>",
+                \str_pad("#$i", $numPad, ' '),
+                (string) $file,
+                $line !== '' ? ":$line" : '',
+                \str_repeat(' ', $numPad),
+                $class,
+                (string) $function,
             );
 
             if ($isFirst) {
                 $isFirst = false;
                 $output->writeln('Stacktrace:');
-                $renderer();
+                $output->writeln($renderedLine);
                 self::renderCodeSnippet($output, $frame, padding: $numPad);
                 continue;
             }
 
+            $renderer = static function () use ($output, $renderedLine): void {
+                $output->writeln($renderedLine);
+            };
             if (!$verbose && \str_starts_with(\ltrim(\str_replace('\\', '/', $file), './'), 'vendor/')) {
                 $vendorLines[] = $renderer;
                 continue;

--- a/src/Socket/Client.php
+++ b/src/Socket/Client.php
@@ -27,13 +27,17 @@ final class Client implements Destroyable
 
     private \Closure $onClose;
 
+    private Timer $selectTimer;
+
     /**
      * @param positive-int $payloadSize
      */
     private function __construct(
         private readonly \Socket $socket,
         private readonly int $payloadSize,
+        float $selectPeriod,
     ) {
+        $this->selectTimer = new Timer($selectPeriod);
         \socket_set_nonblock($this->socket);
         $this->setOnPayload(static fn(string $payload) => null);
         $this->setOnClose(static fn() => null);
@@ -41,12 +45,18 @@ final class Client implements Destroyable
 
     /**
      * @param positive-int $payloadSize Max payload size.
+     * @param float $selectPeriod Time to wait between socket_select() calls in seconds.
      */
     public static function init(
         \Socket $socket,
         int $payloadSize = 10485760,
+        float $selectPeriod = .001,
     ): self {
-        return new self($socket, $payloadSize);
+        return new self(
+            socket: $socket,
+            payloadSize: $payloadSize,
+            selectPeriod: $selectPeriod,
+        );
     }
 
     public function destroy(): void
@@ -103,6 +113,7 @@ final class Client implements Destroyable
                 throw new ClientDisconnected();
             }
             \Fiber::suspend();
+            $this->selectTimer->reset()->wait();
         } while (true);
     }
 

--- a/src/Socket/Server.php
+++ b/src/Socket/Server.php
@@ -10,7 +10,6 @@ use Buggregator\Trap\Logger;
 use Buggregator\Trap\Processable;
 use Buggregator\Trap\Socket\Exception\ClientDisconnected;
 use Buggregator\Trap\Socket\Exception\ServerStopped;
-use Socket;
 
 /**
  * @internal
@@ -27,13 +26,18 @@ final class Server implements Processable, Cancellable, Destroyable
 
     private bool $cancelled = false;
 
+    /** Timestamp with microseconds when last socket_accept() was called */
+    private float $lastAccept = 0;
+
     /**
      * @param null|\Closure(Client, int $id): void $clientInflector
      * @param positive-int $payloadSize Max payload size.
+     * @param float $acceptPeriod Time to wait between socket_accept() calls in seconds.
      */
     private function __construct(
         int $port,
         private readonly int $payloadSize,
+        private readonly float $acceptPeriod,
         private readonly ?\Closure $clientInflector,
         private readonly Logger $logger,
     ) {
@@ -50,15 +54,17 @@ final class Server implements Processable, Cancellable, Destroyable
     /**
      * @param int<1, 65535> $port
      * @param positive-int $payloadSize Max payload size.
+     * @param float $acceptPeriod Time to wait between socket_accept() calls in seconds.
      * @param null|\Closure(Client, int $id): void $clientInflector
      */
     public static function init(
         int $port = 9912,
         int $payloadSize = 10485760,
+        float $acceptPeriod = .001,
         ?\Closure $clientInflector = null,
         Logger $logger = new Logger(),
     ): self {
-        return new self($port, $payloadSize, $clientInflector, $logger);
+        return new self($port, $payloadSize, $acceptPeriod, $clientInflector, $logger);
     }
 
     public function destroy(): void
@@ -82,7 +88,12 @@ final class Server implements Processable, Cancellable, Destroyable
     public function process(): void
     {
         // /** @psalm-suppress PossiblyInvalidArgument */
-        while (!$this->cancelled and false !== ($socket = \socket_accept($this->socket))) {
+        while (match(true) {
+            $this->cancelled,
+            \microtime(true) - $this->lastAccept <= $this->acceptPeriod => false,
+            default => false !== ($socket = \socket_accept($this->socket)),
+        }) {
+            $this->lastAccept = \microtime(true);
             $client = null;
             try {
                 /** @psalm-suppress MixedArgument */

--- a/src/Socket/Server.php
+++ b/src/Socket/Server.php
@@ -97,7 +97,7 @@ final class Server implements Processable, Cancellable, Destroyable
             $client = null;
             try {
                 /** @psalm-suppress MixedArgument */
-                $client = Client::init($socket, $this->payloadSize);
+                $client = Client::init($socket, $this->payloadSize, $this->acceptPeriod);
                 $key = (int) \array_key_last($this->clients) + 1;
                 $this->clients[$key] = $client;
                 $this->clientInflector !== null and ($this->clientInflector)($client, $key);

--- a/src/Socket/Server.php
+++ b/src/Socket/Server.php
@@ -48,7 +48,7 @@ final class Server implements Processable, Cancellable, Destroyable
 
         \socket_set_nonblock($this->socket);
 
-        $logger->status('Application', 'Server started on 127.0.0.1:%s', $port);
+        $logger->status('App', 'Server started on 127.0.0.1:%s', $port);
     }
 
     /**
@@ -96,7 +96,7 @@ final class Server implements Processable, Cancellable, Destroyable
             $this->lastAccept = \microtime(true);
             $client = null;
             try {
-                /** @psalm-suppress MixedArgument */
+                /** @var \Socket $socket */
                 $client = Client::init($socket, $this->payloadSize, $this->acceptPeriod);
                 $key = (int) \array_key_last($this->clients) + 1;
                 $this->clients[$key] = $client;


### PR DESCRIPTION
## What was changed

Separate polling intervals for sockets have been added using the methods socket_select() and socket_accept().

## Why?

To avoid errors on socket resource due to excessively frequent polling of the state.

## Checklist

- Closes #139 
- Tested
  - [x] Tested manually
  - [ ] Unit tests added
