### PR TITLE
Add config for main loop interval and socket polling interval

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Buggregator\Trap;
 
+use Buggregator\Trap\Config\Server\App;
 use Buggregator\Trap\Config\Server\Files\SPX as SPXFileConfig;
 use Buggregator\Trap\Config\Server\Files\XDebug as XDebugFileConfig;
 use Buggregator\Trap\Config\Server\Files\XHProf as XHProfFileConfig;
@@ -113,8 +114,11 @@ final class Application implements Processable, Cancellable, Destroyable
     /**
      * @param positive-int $sleep Sleep time in microseconds
      */
-    public function run(int $sleep = 50): void
+    public function run(): void
     {
+        /** @var App $config */
+        $config = $this->container->get(App::class);
+        $sleep = \max(50, $config->mainLoopInterval);
         foreach ($this->senders as $sender) {
             \assert($sender instanceof Sender);
             if ($sender instanceof Processable) {

--- a/src/Application.php
+++ b/src/Application.php
@@ -10,6 +10,7 @@ use Buggregator\Trap\Config\Server\Files\XDebug as XDebugFileConfig;
 use Buggregator\Trap\Config\Server\Files\XHProf as XHProfFileConfig;
 use Buggregator\Trap\Config\Server\Frontend as FrontendConfig;
 use Buggregator\Trap\Config\Server\SocketServer;
+use Buggregator\Trap\Config\Server\TcpPorts;
 use Buggregator\Trap\Handler\Http\Handler\Websocket;
 use Buggregator\Trap\Handler\Http\Middleware;
 use Buggregator\Trap\Proto\Buffer;
@@ -195,7 +196,7 @@ final class Application implements Processable, Cancellable, Destroyable
      * @param Inspector $inspector
      * @return \Fiber
      */
-    public function prepareServerFiber(SocketServer $config, Inspector $inspector, Logger $logger): \Fiber
+    private function prepareServerFiber(SocketServer $config, Inspector $inspector, Logger $logger): \Fiber
     {
         return $this->fibers[] = new \Fiber(function () use ($config, $inspector, $logger): void {
             do {
@@ -210,7 +211,7 @@ final class Application implements Processable, Cancellable, Destroyable
         });
     }
 
-    public function configureFrontend(bool $separated): void
+    private function configureFrontend(bool $separated): void
     {
         $this->processors[] = $this->senders[] = $wsSender = Sender\FrontendSender::create($this->logger);
         $this->container->set($wsSender);
@@ -230,8 +231,14 @@ final class Application implements Processable, Cancellable, Destroyable
             ),
         ]);
         $this->processors[] = $inspector;
+        /** @var TcpPorts $tcpConfig */
+        $tcpConfig = $this->container->get(TcpPorts::class);
         $config = $this->container->get(FrontendConfig::class);
-        $this->prepareServerFiber(new SocketServer(port: $config->port), $inspector, $this->logger);
+        $this->prepareServerFiber(
+            new SocketServer(port: $config->port, pollingInterval: $tcpConfig->pollingInterval),
+            $inspector,
+            $this->logger,
+        );
     }
 
     /**
@@ -260,7 +267,7 @@ final class Application implements Processable, Cancellable, Destroyable
         return Server::init(
             $config->port,
             payloadSize: 524_288,
-            acceptPeriod: .001,
+            acceptPeriod: \max(50, $config->pollingInterval) / 1e6,
             clientInflector: $clientInflector,
             logger: $this->logger,
         );

--- a/src/Command/Run.php
+++ b/src/Command/Run.php
@@ -60,6 +60,7 @@ final class Run extends Command implements SignalableCommandInterface
      */
     public function getServers(Container $container): array
     {
+        /** @var TcpPorts $config */
         $config = $container->get(TcpPorts::class);
 
         $servers = [];
@@ -73,7 +74,7 @@ final class Run extends Command implements SignalableCommandInterface
             $port > 0 && $port < 65536 or throw new \InvalidArgumentException(
                 \sprintf('Invalid port `%s`. It must be in range 1-65535.', $port),
             );
-            $servers[] = new SocketServer($port, $config->host, $config->type);
+            $servers[] = new SocketServer($port, $config->host, $config->type, $config->pollingInterval);
         }
         return $servers;
     }

--- a/src/Config/Server/App.php
+++ b/src/Config/Server/App.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Buggregator\Trap\Config\Server;
+
+use Buggregator\Trap\Service\Config\Env;
+
+/**
+ * Common configuration for the application
+ *
+ * @internal
+ * @psalm-internal Buggregator\Trap
+ */
+final class App
+{
+    /**
+     * Main loop interval in microseconds
+     * @var int<50, max>
+     */
+    #[Env('TRAP_MAIN_LOOP_INTERVAL')]
+    public int $mainLoopInterval = 100;
+}

--- a/src/Config/Server/SocketServer.php
+++ b/src/Config/Server/SocketServer.php
@@ -12,10 +12,13 @@ final class SocketServer
 {
     /**
      * @param int<1, 65535> $port
+     * @param int<50, max> $pollingInterval Time to wait between socket_accept() and socket_select() calls
+     *        in microseconds.
      */
     public function __construct(
         public readonly int $port,
         public readonly string $host = '127.0.0.1',
         public readonly string $type = 'tcp',
+        public int $pollingInterval = 1_000,
     ) {}
 }

--- a/src/Config/Server/TcpPorts.php
+++ b/src/Config/Server/TcpPorts.php
@@ -33,4 +33,12 @@ final class TcpPorts
     public string $host = '127.0.0.1';
 
     public string $type = 'tcp';
+
+    /**
+     * Time to wait between socket_accept() and socket_select() calls in microseconds.
+     *
+     * @var int<50, max>
+     */
+    #[Env('TRAP_TCP_POLLING_INTERVAL')]
+    public int $pollingInterval = 1_000;
 }


### PR DESCRIPTION
## What was changed

Added envs:
`TRAP_TCP_POLLING_INTERVAL` to configure sockets polling interval
`TRAP_MAIN_LOOP_INTERVAL` to configure main loop interval

## Why?

To empirically determine the best default values.

## Checklist

- Part of #139 
- Tested
  - [ ] Tested manually
  - [ ] Unit tests added
- [ ] Documentation <!--- Remove if not needed -->
