### PR TITLE
Allow `_` in email names in MailToFileSender

### DIFF
--- a/src/Sender/MailToFileSender.php
+++ b/src/Sender/MailToFileSender.php
@@ -52,7 +52,7 @@ class MailToFileSender implements Sender
     private static function normalizeEmail(?string $email): ?string
     {
         $normalized = \preg_replace(
-            ['/[^a-z0-9.\\- @]/i', '/\s+/'],
+            ['/[^a-z0-9.\\-_ @]/i', '/\s+/'],
             ['!', '_'],
             (string) $email,
         );

--- a/tests/Unit/Sender/MailToFileSenderTest.php
+++ b/tests/Unit/Sender/MailToFileSenderTest.php
@@ -36,7 +36,7 @@ final class MailToFileSenderTest extends TestCase
                     'User1 <user1@company.tld>',
                     'user2@company.tld',
                     'User without email', // no email
-                    'User3 <user3@inline.com>, User4 <user4@inline.com>, user5@inline.com',
+                    'User3 <user3@inline.com>, User4 <user4@inline.com>, us_er_5@inline.com',
                 ],
                 'Subject' => ['Very important theme'],
                 'Content-Type' => ['text/plain'],
@@ -50,7 +50,7 @@ final class MailToFileSenderTest extends TestCase
         $this->assertRecipient("$root/user2@company.tld");
         $this->assertRecipient("$root/user3@inline.com");
         $this->assertRecipient("$root/user4@inline.com");
-        $this->assertRecipient("$root/user5@inline.com");
+        $this->assertRecipient("$root/us_er_5@inline.com");
     }
 
     protected function tearDown(): void


### PR DESCRIPTION
## Checklist

- Closes #<!-- add issue number here -->
- Tested
  - [ ] Tested manually
  - [x] Unit tests added
- [ ] Documentation <!--- Remove if not needed -->
