### PR TITLE
Make Senders lazy

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,9 @@
         "websockets",
         "server",
         "helper",
-        "dev"
+        "dev",
+        "fibers",
+        "dumper"
     ],
     "authors": [
         {
@@ -29,16 +31,12 @@
     "homepage": "https://buggregator.dev/",
     "funding": [
         {
-            "type": "github",
-            "url": "https://github.com/sponsors/buggregator"
-        },
-        {
             "type": "patreon",
             "url": "https://patreon.com/roxblnfk"
         },
         {
-            "type": "patreon",
-            "url": "https://patreon.com/butschster"
+            "type": "boosty",
+            "url": "https://boosty.to/roxblnfk"
         }
     ],
     "require": {

--- a/composer.lock
+++ b/composer.lock
@@ -2301,16 +2301,16 @@
         },
         {
             "name": "friendsofphp/php-cs-fixer",
-            "version": "v3.68.0",
+            "version": "v3.68.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer.git",
-                "reference": "73f78d8b2b34a0dd65fedb434a602ee4c2c8ad4c"
+                "reference": "b9db2b2ea3cdba7201067acee46f984ef2397cff"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHP-CS-Fixer/PHP-CS-Fixer/zipball/73f78d8b2b34a0dd65fedb434a602ee4c2c8ad4c",
-                "reference": "73f78d8b2b34a0dd65fedb434a602ee4c2c8ad4c",
+                "url": "https://api.github.com/repos/PHP-CS-Fixer/PHP-CS-Fixer/zipball/b9db2b2ea3cdba7201067acee46f984ef2397cff",
+                "reference": "b9db2b2ea3cdba7201067acee46f984ef2397cff",
                 "shasum": ""
             },
             "require": {
@@ -2392,7 +2392,7 @@
             ],
             "support": {
                 "issues": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/issues",
-                "source": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/tree/v3.68.0"
+                "source": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/tree/v3.68.1"
             },
             "funding": [
                 {
@@ -2400,7 +2400,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-01-13T17:01:01+00:00"
+            "time": "2025-01-17T09:20:36+00:00"
         },
         {
             "name": "google/protobuf",
@@ -3408,16 +3408,16 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "1.12.15",
+            "version": "1.12.16",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "c91d4e8bc056f46cf653656e6f71004b254574d1"
+                "reference": "e0bb5cb78545aae631220735aa706eac633a6be9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/c91d4e8bc056f46cf653656e6f71004b254574d1",
-                "reference": "c91d4e8bc056f46cf653656e6f71004b254574d1",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/e0bb5cb78545aae631220735aa706eac633a6be9",
+                "reference": "e0bb5cb78545aae631220735aa706eac633a6be9",
                 "shasum": ""
             },
             "require": {
@@ -3462,7 +3462,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-01-05T16:40:22+00:00"
+            "time": "2025-01-21T14:50:05+00:00"
         },
         {
             "name": "phpstan/phpstan-deprecation-rules",
@@ -3565,16 +3565,16 @@
         },
         {
             "name": "phpstan/phpstan-strict-rules",
-            "version": "1.6.1",
+            "version": "1.6.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan-strict-rules.git",
-                "reference": "daeec748b53de80a97498462513066834ec28f8b"
+                "reference": "b564ca479e7e735f750aaac4935af965572a7845"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan-strict-rules/zipball/daeec748b53de80a97498462513066834ec28f8b",
-                "reference": "daeec748b53de80a97498462513066834ec28f8b",
+                "url": "https://api.github.com/repos/phpstan/phpstan-strict-rules/zipball/b564ca479e7e735f750aaac4935af965572a7845",
+                "reference": "b564ca479e7e735f750aaac4935af965572a7845",
                 "shasum": ""
             },
             "require": {
@@ -3608,9 +3608,9 @@
             "description": "Extra strict and opinionated rules for PHPStan",
             "support": {
                 "issues": "https://github.com/phpstan/phpstan-strict-rules/issues",
-                "source": "https://github.com/phpstan/phpstan-strict-rules/tree/1.6.1"
+                "source": "https://github.com/phpstan/phpstan-strict-rules/tree/1.6.2"
             },
-            "time": "2024-09-20T14:04:44+00:00"
+            "time": "2025-01-19T13:02:24+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",

--- a/src/Command/Run.php
+++ b/src/Command/Run.php
@@ -80,17 +80,11 @@ final class Run extends Command implements SignalableCommandInterface
     public function createRegistry(OutputInterface $output): Sender\SenderRegistry
     {
         $registry = new Sender\SenderRegistry();
-        $registry->register('console', Sender\ConsoleSender::create($output));
-        $registry->register('file', new Sender\EventsToFileSender());
-        $registry->register('file-body', new Sender\BodyToFileSender());
-        $registry->register('mail-to-file', new Sender\MailToFileSender());
-        $registry->register(
-            'server',
-            new Sender\RemoteSender(
-                host: '127.0.0.1',
-                port: 9099,
-            ),
-        );
+        $registry->register('console', static fn(): Sender => Sender\ConsoleSender::create($output));
+        $registry->register('file', static fn(): Sender => new Sender\EventsToFileSender());
+        $registry->register('file-body', static fn(): Sender => new Sender\BodyToFileSender());
+        $registry->register('mail-to-file', static fn(): Sender => new Sender\MailToFileSender());
+        $registry->register('server', static fn(): Sender => new Sender\RemoteSender(host: '127.0.0.1', port: 9099));
 
         return $registry;
     }


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR!
If it is a significant code change, please **make sure there is an open issue** for this.
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed

All the senders now are created when needed

## Why?

To avoid creating unnecessary directories during ***toFile senders initialization