### PR TITLE
Fix Sentry envelope parsing

### DIFF
--- a/src/Handler/Http/Middleware/SentryTrap/EnvelopeParser.php
+++ b/src/Handler/Http/Middleware/SentryTrap/EnvelopeParser.php
@@ -23,7 +23,7 @@ final class EnvelopeParser
         \DateTimeImmutable $time = new \DateTimeImmutable(),
     ): SentryEnvelope {
         // Parse headers
-        $headers = \json_decode(self::readLine($stream), true, 4, JSON_THROW_ON_ERROR);
+        $headers = \json_decode(self::readLine($stream), true, 32, JSON_THROW_ON_ERROR);
 
         // Parse items
         $items = [];

--- a/src/Sender/Console/Renderer/Sentry/Header.php
+++ b/src/Sender/Console/Renderer/Sentry/Header.php
@@ -36,7 +36,7 @@ final class Header
             isset($context['os']) and $meta['OS'] = \implode(' ', (array) $context['os']);
         }
         $headersList = \array_map(
-            fn(mixed $value): string => \is_scalar($value) ? (string) $value : Json::encode($value),
+            static fn(mixed $value): string => \is_scalar($value) ? (string) $value : Json::encode($value),
             (array) $message['sdk'],
         );
         isset($message['sdk']) and $meta['SDK'] = \implode(' ', $headersList);

--- a/src/Sender/Console/Renderer/Sentry/Header.php
+++ b/src/Sender/Console/Renderer/Sentry/Header.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Buggregator\Trap\Sender\Console\Renderer\Sentry;
 
 use Buggregator\Trap\Sender\Console\Support\Common;
+use Buggregator\Trap\Support\Json;
 use Symfony\Component\Console\Output\OutputInterface;
 
 /**
@@ -34,7 +35,11 @@ final class Header
             isset($context['runtime']) and $meta['Runtime'] = \implode(' ', (array) $context['runtime']);
             isset($context['os']) and $meta['OS'] = \implode(' ', (array) $context['os']);
         }
-        isset($message['sdk']) and $meta['SDK'] = \implode(' ', (array) $message['sdk']);
+        $headersList = \array_map(
+            fn(mixed $value): string => \is_scalar($value) ? (string) $value : Json::encode($value),
+            (array) $message['sdk'],
+        );
+        isset($message['sdk']) and $meta['SDK'] = \implode(' ', $headersList);
 
         Common::renderMetadata($output, $meta);
 


### PR DESCRIPTION
## What was changed

Increased parsing JSON level.

## Why?

Sentry messages nay have greater level than 4.

Fix #182 
