### PR TITLE
feat: add PSR-3 Trap logger with STDERR fallback

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -46,7 +46,7 @@
         "php-http/message": "^1.15",
         "psr/container": "^1.1 || ^2.0",
         "psr/http-message": "^1.1 || ^2",
-        "psr/log": "^1 || ^2 || ^3",
+        "psr/log": "^2 || ^3",
         "symfony/console": "^6.4 || ^7 || ^8",
         "symfony/var-dumper": "^6.3 || ^7 || ^8",
         "yiisoft/injector": "^1.2"

--- a/composer.json
+++ b/composer.json
@@ -46,6 +46,7 @@
         "php-http/message": "^1.15",
         "psr/container": "^1.1 || ^2.0",
         "psr/http-message": "^1.1 || ^2",
+        "psr/log": "^1 || ^2 || ^3",
         "symfony/console": "^6.4 || ^7 || ^8",
         "symfony/var-dumper": "^6.3 || ^7 || ^8",
         "yiisoft/injector": "^1.2"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "806dadc13d17b51e81ef302320f56d58",
+    "content-hash": "801a4d8130bec361cced423e73f5c798",
     "packages": [
         {
             "name": "clue/stream-filter",
@@ -438,6 +438,56 @@
                 "source": "https://github.com/php-fig/http-message/tree/2.0"
             },
             "time": "2023-04-04T09:54:51+00:00"
+        },
+        {
+            "name": "psr/log",
+            "version": "3.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/log.git",
+                "reference": "f16e1d5863e37f8d8c2a01719f5b34baa2b714d3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/log/zipball/f16e1d5863e37f8d8c2a01719f5b34baa2b714d3",
+                "reference": "f16e1d5863e37f8d8c2a01719f5b34baa2b714d3",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.0.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Log\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for logging libraries",
+            "homepage": "https://github.com/php-fig/log",
+            "keywords": [
+                "log",
+                "psr",
+                "psr-3"
+            ],
+            "support": {
+                "source": "https://github.com/php-fig/log/tree/3.0.2"
+            },
+            "time": "2024-09-11T13:17:53+00:00"
         },
         {
             "name": "symfony/console",
@@ -4058,56 +4108,6 @@
                 }
             ],
             "time": "2025-12-06T07:50:42+00:00"
-        },
-        {
-            "name": "psr/log",
-            "version": "3.0.2",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/php-fig/log.git",
-                "reference": "f16e1d5863e37f8d8c2a01719f5b34baa2b714d3"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/log/zipball/f16e1d5863e37f8d8c2a01719f5b34baa2b714d3",
-                "reference": "f16e1d5863e37f8d8c2a01719f5b34baa2b714d3",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=8.0.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "3.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Psr\\Log\\": "src"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "PHP-FIG",
-                    "homepage": "https://www.php-fig.org/"
-                }
-            ],
-            "description": "Common interface for logging libraries",
-            "homepage": "https://github.com/php-fig/log",
-            "keywords": [
-                "log",
-                "psr",
-                "psr-3"
-            ],
-            "support": {
-                "source": "https://github.com/php-fig/log/tree/3.0.2"
-            },
-            "time": "2024-09-11T13:17:53+00:00"
         },
         {
             "name": "rector/rector",

--- a/src/Client/TrapHandle.php
+++ b/src/Client/TrapHandle.php
@@ -22,7 +22,9 @@ final class TrapHandle
     private string $timesCounterKey = '';
     private int $depth = 0;
     private readonly StaticState $staticState;
-    private static ?TrapLogger $logger = null;
+
+    /** @var array<string, TrapLogger> */
+    private static array $loggers = [];
 
     private function __construct(
         private array $values,
@@ -43,26 +45,33 @@ final class TrapHandle
      *
      * Uses TRAP_MONOLOG_HOST and TRAP_MONOLOG_PORT env variables,
      * falling back to 127.0.0.1:9913.
+     *
+     * @param non-empty-string $channel Monolog channel name the records will be tagged with.
      */
-    public static function logger(): LoggerInterface
+    public static function logger(string $channel = 'trap'): LoggerInterface
     {
-        if (self::$logger === null) {
-            $host = self::getEnvValue('TRAP_MONOLOG_HOST', '127.0.0.1');
-            $port = self::getEnvValue('TRAP_MONOLOG_PORT', '9913');
+        return self::$loggers[$channel] ??= self::createLogger($channel);
+    }
 
-            $port = \is_numeric($port) ? (int) $port : 9913;
+    /**
+     * @param non-empty-string $channel
+     */
+    private static function createLogger(string $channel): TrapLogger
+    {
+        $host = self::getEnvValue('TRAP_MONOLOG_HOST', '127.0.0.1');
+        $port = self::getEnvValue('TRAP_MONOLOG_PORT', '9913');
 
-            if ($port < 1 || $port > 65535) {
-                $port = 9913;
-            }
+        $port = \is_numeric($port) ? (int) $port : 9913;
 
-            self::$logger = new TrapLogger(
-                host: $host,
-                port: $port,
-            );
+        if ($port < 1 || $port > 65535) {
+            $port = 9913;
         }
 
-        return self::$logger;
+        return new TrapLogger(
+            host: $host,
+            port: $port,
+            channel: $channel,
+        );
     }
 
     /**

--- a/src/Client/TrapHandle.php
+++ b/src/Client/TrapHandle.php
@@ -48,7 +48,13 @@ final class TrapHandle
     {
         if (self::$logger === null) {
             $host = self::getEnvValue('TRAP_MONOLOG_HOST', '127.0.0.1');
-            $port = (int) self::getEnvValue('TRAP_MONOLOG_PORT', '9913');
+            $port = self::getEnvValue('TRAP_MONOLOG_PORT', '9913');
+
+            $port = \is_numeric($port) ? (int) $port : 9913;
+
+            if ($port < 1 || $port > 65535) {
+                $port = 9913;
+            }
 
             self::$logger = new TrapLogger(
                 host: $host,

--- a/src/Client/TrapHandle.php
+++ b/src/Client/TrapHandle.php
@@ -8,6 +8,8 @@ use Buggregator\Trap\Client\Caster\Trace;
 use Buggregator\Trap\Client\TrapHandle\Counter;
 use Buggregator\Trap\Client\TrapHandle\Dumper as VarDumper;
 use Buggregator\Trap\Client\TrapHandle\StaticState;
+use Buggregator\Trap\Log\TrapLogger;
+use Psr\Log\LoggerInterface;
 use Symfony\Component\VarDumper\Caster\TraceStub;
 
 /**
@@ -20,6 +22,7 @@ final class TrapHandle
     private string $timesCounterKey = '';
     private int $depth = 0;
     private readonly StaticState $staticState;
+    private static ?TrapLogger $logger = null;
 
     private function __construct(
         private array $values,
@@ -33,6 +36,27 @@ final class TrapHandle
     public static function fromArray(array $array): self
     {
         return new self($array);
+    }
+
+    /**
+     * Get a PSR-3 compatible logger instance for Trap client logging.
+     *
+     * Uses TRAP_MONOLOG_HOST and TRAP_MONOLOG_PORT env variables,
+     * falling back to 127.0.0.1:9913.
+     */
+    public static function logger(): LoggerInterface
+    {
+        if (self::$logger === null) {
+            $host = self::getEnvValue('TRAP_MONOLOG_HOST', '127.0.0.1');
+            $port = (int) self::getEnvValue('TRAP_MONOLOG_PORT', '9913');
+
+            self::$logger = new TrapLogger(
+                host: $host,
+                port: $port,
+            );
+        }
+
+        return self::$logger;
     }
 
     /**
@@ -214,6 +238,25 @@ final class TrapHandle
         $this->haveToSend() and $this->sendDump();
     }
 
+    private static function getEnvValue(string $name, string $default): string
+    {
+        if (\array_key_exists($name, $_ENV)) {
+            return $_ENV[$name];
+        }
+
+        $value = \getenv($name, true);
+        if ($value !== false) {
+            return $value;
+        }
+
+        $value = \getenv($name);
+        if ($value !== false) {
+            return $value;
+        }
+
+        return $default;
+    }
+
     private function sendDump(): void
     {
         $staticState = StaticState::getValue();
@@ -223,9 +266,9 @@ final class TrapHandle
         try {
             // Set default values if not set
             if (!isset($_SERVER['VAR_DUMPER_FORMAT'], $_SERVER['VAR_DUMPER_SERVER'])) {
-                $_SERVER['VAR_DUMPER_FORMAT'] = $this->getEnvValue('VAR_DUMPER_FORMAT', 'server');
+                $_SERVER['VAR_DUMPER_FORMAT'] = self::getEnvValue('VAR_DUMPER_FORMAT', 'server');
                 // todo use the config file in the future
-                $_SERVER['VAR_DUMPER_SERVER'] = $this->getEnvValue('VAR_DUMPER_SERVER', '127.0.0.1:9912');
+                $_SERVER['VAR_DUMPER_SERVER'] = self::getEnvValue('VAR_DUMPER_SERVER', '127.0.0.1:9912');
             }
 
             // Dump single value
@@ -246,25 +289,6 @@ final class TrapHandle
         } finally {
             StaticState::setState($staticState);
         }
-    }
-
-    private function getEnvValue(string $name, string $default): string
-    {
-        if (\array_key_exists($name, $_ENV)) {
-            return $_ENV[$name];
-        }
-
-        $value = \getenv($name, true);
-        if ($value !== false) {
-            return $value;
-        }
-
-        $value = \getenv($name);
-        if ($value !== false) {
-            return $value;
-        }
-
-        return $default;
     }
 
     private function haveToSend(): bool

--- a/src/Log/TrapLogger.php
+++ b/src/Log/TrapLogger.php
@@ -20,6 +20,9 @@ use Psr\Log\AbstractLogger;
  */
 final class TrapLogger extends AbstractLogger
 {
+    private const ASYNC_WRITE_RETRY_COUNT = 3;
+    private const ASYNC_WRITE_RETRY_DELAY_MICROSECONDS = 5_000;
+
     public function __construct(
         private string $host = '127.0.0.1',
         private int $port = 9913,
@@ -82,6 +85,8 @@ final class TrapLogger extends AbstractLogger
             return false;
         }
 
+        @\stream_set_timeout($stream, (int) $this->connectTimeout, (int) ($this->connectTimeout * 1000000 % 1000000));
+
         try {
             $payload .= "\n";
             $offset = 0;
@@ -133,11 +138,26 @@ final class TrapLogger extends AbstractLogger
             $length = \strlen($payload);
 
             while ($offset < $length) {
-                $write = [$stream];
-                $read = [];
-                $except = [];
+                $isWritable = false;
 
-                if (@\stream_select($read, $write, $except, 0, 0) !== 1) {
+                for ($attempt = 0; $attempt < self::ASYNC_WRITE_RETRY_COUNT; $attempt++) {
+                    $write = [$stream];
+                    $read = [];
+                    $except = [];
+
+                    $result = @\stream_select($read, $write, $except, 0, self::ASYNC_WRITE_RETRY_DELAY_MICROSECONDS);
+
+                    if ($result === 1) {
+                        $isWritable = true;
+                        break;
+                    }
+
+                    if ($result === false) {
+                        return false;
+                    }
+                }
+
+                if (!$isWritable) {
                     return false;
                 }
 

--- a/src/Log/TrapLogger.php
+++ b/src/Log/TrapLogger.php
@@ -23,6 +23,9 @@ final class TrapLogger extends AbstractLogger
     private const ASYNC_WRITE_RETRY_COUNT = 3;
     private const ASYNC_WRITE_RETRY_DELAY_MICROSECONDS = 5_000;
 
+    /**
+     * @param non-empty-string $channel
+     */
     public function __construct(
         private string $host = '127.0.0.1',
         private int $port = 9913,
@@ -85,7 +88,12 @@ final class TrapLogger extends AbstractLogger
             return false;
         }
 
-        @\stream_set_timeout($stream, (int) $this->connectTimeout, (int) ($this->connectTimeout * 1000000 % 1000000));
+        $timeoutMicroseconds = (int) ($this->connectTimeout * 1_000_000.0);
+        @\stream_set_timeout(
+            $stream,
+            \intdiv($timeoutMicroseconds, 1_000_000),
+            $timeoutMicroseconds % 1_000_000,
+        );
 
         try {
             $payload .= "\n";

--- a/src/Log/TrapLogger.php
+++ b/src/Log/TrapLogger.php
@@ -1,0 +1,271 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Buggregator\Trap\Log;
+
+use Psr\Log\InvalidArgumentException;
+use Psr\Log\AbstractLogger;
+
+/**
+ * @psalm-type LogRecord = array{
+ *     message: string,
+ *     context: array<array-key, mixed>,
+ *     level: int,
+ *     level_name: string,
+ *     channel: string,
+ *     datetime: string,
+ *     extra: array<array-key, mixed>
+ * }
+ */
+final class TrapLogger extends AbstractLogger
+{
+    public function __construct(
+        private string $host = '127.0.0.1',
+        private int $port = 9913,
+        private string $channel = 'trap',
+        private float $connectTimeout = 0.5,
+    ) {}
+
+    /**
+     * Sends a log record to the Trap server in Monolog-compatible JSON format,
+     * falling back to STDERR if the connection fails.
+     */
+    public function log(mixed $level, string|\Stringable $message, array $context = []): void
+    {
+        $level = \strtolower((string) $level);
+
+        $record = $this->createRecord($level, $message, $context);
+
+        $payload = \json_encode($record, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+
+        if ($payload === false) {
+            $this->writeFallback($record);
+
+            return;
+        }
+
+        if (!$this->sendToTrap($payload)) {
+            $this->writeFallback($record);
+        }
+    }
+
+    /**
+     * Routes the payload to the appropriate send method
+     * based on whether we are currently inside a Fiber.
+     */
+    private function sendToTrap(string $payload): bool
+    {
+        return \Fiber::getCurrent() === null
+            ? $this->sendSync($payload)
+            : $this->sendAsync($payload);
+    }
+
+    /**
+     * Sends the payload synchronously using a blocking TCP connection.
+     */
+    private function sendSync(string $payload): bool
+    {
+        $address = \sprintf('tcp://%s:%d', $this->host, $this->port);
+
+        $errorCode = 0;
+        $errorMessage = '';
+
+        $stream = @\stream_socket_client(
+            $address,
+            $errorCode,
+            $errorMessage,
+            $this->connectTimeout,
+        );
+
+        if ($stream === false) {
+            return false;
+        }
+
+        try {
+            $payload .= "\n";
+            $offset = 0;
+            $length = \strlen($payload);
+
+            while ($offset < $length) {
+                $written = @\fwrite($stream, \substr($payload, $offset));
+
+                if (!\is_int($written) || $written <= 0) {
+                    return false;
+                }
+
+                $offset += $written;
+            }
+
+            return true;
+        } finally {
+            \fclose($stream);
+        }
+    }
+
+    /**
+     * Sends the payload using a non-blocking TCP connection.
+     */
+    private function sendAsync(string $payload): bool
+    {
+        $address = \sprintf('tcp://%s:%d', $this->host, $this->port);
+
+        $errorCode = 0;
+        $errorMessage = '';
+
+        $stream = @\stream_socket_client(
+            $address,
+            $errorCode,
+            $errorMessage,
+            $this->connectTimeout,
+            STREAM_CLIENT_CONNECT | STREAM_CLIENT_ASYNC_CONNECT,
+        );
+
+        if ($stream === false) {
+            return false;
+        }
+
+        @\stream_set_blocking($stream, false);
+
+        try {
+            $payload .= "\n";
+            $offset = 0;
+            $length = \strlen($payload);
+
+            while ($offset < $length) {
+                $write = [$stream];
+                $read = [];
+                $except = [];
+
+                if (@\stream_select($read, $write, $except, 0, 0) !== 1) {
+                    return false;
+                }
+
+                $written = @\fwrite($stream, \substr($payload, $offset));
+
+                if (!\is_int($written) || $written <= 0) {
+                    return false;
+                }
+
+                $offset += $written;
+            }
+
+            return true;
+        } finally {
+            \fclose($stream);
+        }
+    }
+
+    /**
+     * Replaces {placeholder} tokens in the message with values from context.
+     * Follows PSR-3 placeholder interpolation rules.
+     *
+     * @param array<array-key, mixed> $context
+     */
+    private function interpolate(string $message, array $context): string
+    {
+        if ($context === [] || !\str_contains($message, '{')) {
+            return $message;
+        }
+
+        $replacements = [];
+
+        /** @psalm-suppress MixedAssignment */
+        foreach ($context as $key => $value) {
+            if (\is_object($value) && !\method_exists($value, '__toString')) {
+                $replacements['{' . (string) $key . '}'] = \get_class($value);
+
+                continue;
+            }
+
+            if (\is_array($value)) {
+                $valueJson = \json_encode($value, JSON_UNESCAPED_UNICODE);
+
+                $replacements['{' . (string) $key . '}'] = $valueJson !== false
+                    ? $valueJson
+                    : '[unserializable array]';
+
+                continue;
+            }
+
+            $replacements['{' . (string) $key . '}'] = (string) $value;
+        }
+
+        return \strtr($message, $replacements);
+    }
+
+    /**
+     * @param LogRecord $record
+     */
+    private function writeFallback(array $record): void
+    {
+        $line = $this->formatFallbackLine($record);
+
+        if (\defined('STDERR')) {
+            \fwrite(\STDERR, $line . \PHP_EOL);
+        } else {
+            \error_log($line);
+        }
+    }
+
+    /**
+     * @param LogRecord $record
+     */
+    private function formatFallbackLine(array $record): string
+    {
+        $contextJson = \json_encode($record['context'], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+
+        return \sprintf(
+            '[%s] %s.%s: %s %s',
+            $record['datetime'],
+            $record['channel'],
+            $record['level_name'],
+            $record['message'],
+            $contextJson !== false ? $contextJson : '[unserializable context]',
+        );
+    }
+
+    /**
+     * Builds a Monolog-compatible log record array from the given level, message and context.
+     *
+     * @param array<array-key, mixed> $context
+     * @return LogRecord
+     */
+    private function createRecord(string $level, string|\Stringable $message, array $context): array
+    {
+        $interpolated = $this->interpolate((string) $message, $context);
+
+        return [
+            'message'    => $interpolated,
+            'context'    => $context,
+            'level'      => $this->mapLevelToInt($level),
+            'level_name' => \strtoupper($level),
+            'channel'    => $this->channel,
+            'datetime'   => (new \DateTimeImmutable())->format(\DateTimeInterface::RFC3339_EXTENDED),
+            'extra'      => [],
+        ];
+    }
+
+    /**
+     * Map PSR-3 level name to Monolog-style integer level.
+     */
+    private function mapLevelToInt(string $level): int
+    {
+        $levelMap = [
+            'debug' => 100,
+            'info' => 200,
+            'notice' => 250,
+            'warning' => 300,
+            'error' => 400,
+            'critical' => 500,
+            'alert' => 550,
+            'emergency' => 600,
+        ];
+
+        if (!isset($levelMap[$level])) {
+            throw new InvalidArgumentException(\sprintf('Invalid log level "%s".', $level));
+        }
+
+        return $levelMap[$level];
+    }
+}

--- a/tests/Unit/Client/TrapLoggerTest.php
+++ b/tests/Unit/Client/TrapLoggerTest.php
@@ -21,6 +21,28 @@ final class TrapLoggerTest extends Base
         self::assertSame($logger1, $logger2);
     }
 
+    public function testLoggerUsesDefaultChannel(): void
+    {
+        $logger = TrapHandle::logger();
+
+        self::assertInstanceOf(TrapLogger::class, $logger);
+        self::assertSame('trap', $this->getLoggerChannel($logger));
+    }
+
+    public function testLoggerUsesProvidedChannel(): void
+    {
+        $logger = TrapHandle::logger('app');
+
+        self::assertInstanceOf(TrapLogger::class, $logger);
+        self::assertSame('app', $this->getLoggerChannel($logger));
+    }
+
+    public function testLoggerCachesInstancePerChannel(): void
+    {
+        self::assertSame(TrapHandle::logger('app'), TrapHandle::logger('app'));
+        self::assertNotSame(TrapHandle::logger('app'), TrapHandle::logger('worker'));
+    }
+
     public function testLoggerSendsToServer(): void
     {
         $server = \stream_socket_server('tcp://127.0.0.1:0', $errorCode, $errorMessage);
@@ -121,8 +143,8 @@ final class TrapLoggerTest extends Base
     private function resetTrapLogger(): void
     {
         $reflection = new \ReflectionClass(TrapHandle::class);
-        $logger = $reflection->getProperty('logger');
-        $logger->setValue(null, null);
+        $loggers = $reflection->getProperty('loggers');
+        $loggers->setValue(null, []);
     }
 
     private function getLoggerPort(TrapLogger $logger): int
@@ -131,5 +153,13 @@ final class TrapLoggerTest extends Base
         $port = $reflection->getProperty('port');
 
         return $port->getValue($logger);
+    }
+
+    private function getLoggerChannel(TrapLogger $logger): string
+    {
+        $reflection = new \ReflectionClass($logger);
+        $channel = $reflection->getProperty('channel');
+
+        return $channel->getValue($logger);
     }
 }

--- a/tests/Unit/Client/TrapLoggerTest.php
+++ b/tests/Unit/Client/TrapLoggerTest.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Buggregator\Trap\Tests\Unit\Client;
+
+use Buggregator\Trap\Client\TrapHandle;
+use Buggregator\Trap\Log\TrapLogger;
+use Psr\Log\InvalidArgumentException;
+use Psr\Log\LoggerInterface;
+
+final class TrapLoggerTest extends Base
+{
+    public function testLoggerReturnsSameInstance(): void
+    {
+        $logger1 = TrapHandle::logger();
+        $logger2 = TrapHandle::logger();
+
+        self::assertInstanceOf(LoggerInterface::class, $logger1);
+        self::assertInstanceOf(TrapLogger::class, $logger1);
+        self::assertSame($logger1, $logger2);
+    }
+
+    public function testLoggerCanWriteInfo(): void
+    {
+        $logger = new TrapLogger(host: '127.0.0.1', port: 1);
+
+        $logger->info('Hello {name}', ['name' => 'Trap']);
+
+        self::assertTrue(true);
+    }
+
+    public function testLoggerCanWriteError(): void
+    {
+        $logger = new TrapLogger(host: '127.0.0.1', port: 1);
+
+        $logger->error('Something went wrong: {error}', ['error' => 'boom']);
+
+        self::assertTrue(true);
+    }
+
+    public function testFallbackLineIsTextFormatted(): void
+    {
+        $logger = new TrapLogger(host: '127.0.0.1', port: 1);
+        $reflection = new \ReflectionClass($logger);
+
+        $createRecord = $reflection->getMethod('createRecord');
+        $formatFallbackLine = $reflection->getMethod('formatFallbackLine');
+
+        $record = $createRecord->invoke(
+            $logger,
+            'error',
+            'Something went wrong: {error}',
+            ['error' => 'boom'],
+        );
+
+        $line = $formatFallbackLine->invoke($logger, $record);
+
+        self::assertStringStartsWith('[', $line);
+        self::assertStringContainsString('trap.ERROR: Something went wrong: boom', $line);
+        self::assertStringContainsString('{"error":"boom"}', $line);
+    }
+
+    public function testInvalidLevelThrowsException(): void
+    {
+        $logger = new TrapLogger(host: '127.0.0.1', port: 1);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid log level "invalid".');
+
+        $logger->log('invalid', 'Bad level');
+    }
+}

--- a/tests/Unit/Client/TrapLoggerTest.php
+++ b/tests/Unit/Client/TrapLoggerTest.php
@@ -21,22 +21,55 @@ final class TrapLoggerTest extends Base
         self::assertSame($logger1, $logger2);
     }
 
-    public function testLoggerCanWriteInfo(): void
+    public function testLoggerSendsToServer(): void
     {
-        $logger = new TrapLogger(host: '127.0.0.1', port: 1);
+        $server = \stream_socket_server('tcp://127.0.0.1:0', $errorCode, $errorMessage);
+        self::assertNotFalse($server);
 
-        $logger->info('Hello {name}', ['name' => 'Trap']);
+        try {
+            $address = \stream_socket_get_name($server, false);
+            self::assertIsString($address);
 
-        self::assertTrue(true);
+            [, $port] = \explode(':', $address);
+
+            $logger = new TrapLogger(host: '127.0.0.1', port: (int) $port);
+            $logger->info('Hello {name}', ['name' => 'Trap']);
+
+            $client = @\stream_socket_accept($server, 1);
+            self::assertNotFalse($client);
+
+            $line = \stream_get_line($client, 8192, "\n");
+            self::assertNotFalse($line);
+
+            $payload = \json_decode($line, true);
+
+            self::assertSame('Hello Trap', $payload['message']);
+            self::assertSame('INFO', $payload['level_name']);
+            self::assertSame(['name' => 'Trap'], $payload['context']);
+        } finally {
+            if (\is_resource($client ?? null)) {
+                \fclose($client);
+            }
+            \fclose($server);
+        }
     }
 
-    public function testLoggerCanWriteError(): void
+    public function testLoggerFallsBackToDefaultPort(): void
     {
-        $logger = new TrapLogger(host: '127.0.0.1', port: 1);
+        \putenv('TRAP_MONOLOG_PORT=invalid');
 
-        $logger->error('Something went wrong: {error}', ['error' => 'boom']);
+        $logger = TrapHandle::logger();
 
-        self::assertTrue(true);
+        self::assertInstanceOf(TrapLogger::class, $logger);
+        self::assertSame(9913, $this->getLoggerPort($logger));
+
+        $this->resetTrapLogger();
+        \putenv('TRAP_MONOLOG_PORT=70000');
+
+        $logger = TrapHandle::logger();
+
+        self::assertInstanceOf(TrapLogger::class, $logger);
+        self::assertSame(9913, $this->getLoggerPort($logger));
     }
 
     public function testFallbackLineIsTextFormatted(): void
@@ -69,5 +102,34 @@ final class TrapLoggerTest extends Base
         $this->expectExceptionMessage('Invalid log level "invalid".');
 
         $logger->log('invalid', 'Bad level');
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->resetTrapLogger();
+        \putenv('TRAP_MONOLOG_PORT');
+    }
+
+    protected function tearDown(): void
+    {
+        $this->resetTrapLogger();
+        \putenv('TRAP_MONOLOG_PORT');
+        parent::tearDown();
+    }
+
+    private function resetTrapLogger(): void
+    {
+        $reflection = new \ReflectionClass(TrapHandle::class);
+        $logger = $reflection->getProperty('logger');
+        $logger->setValue(null, null);
+    }
+
+    private function getLoggerPort(TrapLogger $logger): int
+    {
+        $reflection = new \ReflectionClass($logger);
+        $port = $reflection->getProperty('port');
+
+        return $port->getValue($logger);
     }
 }


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR!
If it is a significant code change, please **make sure there is an open issue** for this.
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
- Added a standalone PSR-3 logger entrypoint via `trap()::logger()`
- Introduced `TrapLogger` based on `psr/log`
- Implemented log delivery to the Trap Monolog TCP port using Monolog-compatible JSON payloads
- Added graceful fallback to plain-text `STDERR` output when Trap server delivery fails
- Added support for both sync execution and fiber-aware async execution
- Added environment-based configuration for logger transport via `TRAP_MONOLOG_HOST` and `TRAP_MONOLOG_PORT`
- Added unit tests for logger access, invalid level handling, and fallback formatting

## Why?
The issue asks for a standalone PSR-3 logger implementation for the client side of the project, accessible via `trap()::logger()`.

This makes Trap usable in places where a PSR-3 logger is expected without requiring Monolog as the application logger. The logger tries to send records to the Trap server first, and falls back to `STDERR` in text format when delivery is not possible.

The async/fiber path is implemented as best-effort non-blocking behavior to avoid interfering with fiber-based execution.


## Checklist

- Closes #179 
- Tested
  - [x] Tested manually
  - [x] Unit tests added
- [ ] Documentation - will add later if PR fits the need

## Notes

The fiber/async path is implemented as best-effort non-blocking behavior.

I’m open to adjusting it if a different async strategy is preferred.